### PR TITLE
feat(admin): PR Part 2 - Refactor UI tables and list layouts

### DIFF
--- a/src/components/cbt/kerjakan/ExamContext.tsx
+++ b/src/components/cbt/kerjakan/ExamContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+import type { useExamState } from "./useExamState";
+import type { Ujian, SesiUjian } from "@/lib/cbt/types";
+
+type ExamContextType = ReturnType<typeof useExamState> & {
+  ujian: Ujian;
+  sesi: SesiUjian; // non-null since context is wrapped when sesi exists
+};
+
+export const ExamContext = createContext<ExamContextType | null>(null);
+
+export function useExamContext() {
+  const ctx = useContext(ExamContext);
+  if (!ctx) {
+    throw new Error("useExamContext must be used within ExamContextProvider");
+  }
+  return ctx;
+}

--- a/src/components/cbt/kerjakan/ExamFooter.tsx
+++ b/src/components/cbt/kerjakan/ExamFooter.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useExamContext } from "./ExamContext";
+
+export function ExamFooter() {
+  const { sesi, idx, handleNavigateIdx, updateJawaban, submit } = useExamContext();
+  const currentJawaban = sesi.jawaban[idx];
+
+  return (
+    <div className="sticky bottom-0 z-20 bg-white/90 dark:bg-slate-900/90 backdrop-blur-xl border-t border-slate-200 dark:border-slate-800 p-4 sm:p-6">
+      <div className="max-w-4xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
+        
+        <div className="flex w-full sm:w-auto items-center gap-3">
+          <Button
+            variant="outline"
+            size="lg"
+            className="w-full sm:w-auto font-bold rounded-xl border-2 border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-600 dark:text-slate-300 h-14 px-6 transition-all"
+            disabled={idx === 0}
+            onClick={() => handleNavigateIdx(idx - 1)}
+          >
+            <ChevronLeft className="w-5 h-5 mr-1" /> SEBELUMNYA
+          </Button>
+
+          <label className={cn(
+            "flex-1 sm:flex-none flex items-center justify-center gap-2 cursor-pointer h-14 px-6 rounded-xl font-bold uppercase tracking-wider transition-all border-2 select-none",
+            currentJawaban.ragu 
+              ? "bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-700 shadow-sm" 
+              : "bg-white dark:bg-slate-900 text-slate-500 dark:text-slate-400 border-slate-200 dark:border-slate-700 hover:border-amber-200 dark:hover:border-amber-800/50 hover:bg-amber-50 dark:hover:bg-amber-950/20"
+          )}>
+            <input 
+              type="checkbox" 
+              className="w-5 h-5 accent-amber-500 rounded cursor-pointer"
+              checked={currentJawaban.ragu}
+              onChange={(e) => updateJawaban({ ragu: e.target.checked })}
+            />
+            RAGU-RAGU
+          </label>
+        </div>
+
+        {idx < sesi.soalIds.length - 1 ? (
+          <Button
+            size="lg"
+            className="w-full sm:w-auto h-14 px-8 rounded-xl font-bold uppercase tracking-widest shadow-md hover:shadow-lg transition-all hover:-translate-y-0.5"
+            onClick={() => handleNavigateIdx(idx + 1)}
+          >
+            SELANJUTNYA <ChevronRight className="w-5 h-5 ml-1" />
+          </Button>
+        ) : (
+          <Button
+            size="lg"
+            variant="destructive"
+            className="w-full sm:w-auto h-14 px-8 rounded-xl font-black uppercase tracking-widest shadow-lg shadow-red-500/20 hover:shadow-red-500/40 transition-all hover:-translate-y-0.5"
+            onClick={() => {
+              if (confirm("Pastikan semua jawaban telah terisi dengan benar. Yakin kumpulkan ujian sekarang?")) void submit();
+            }}
+          >
+            KUMPULKAN
+          </Button>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/src/components/cbt/kerjakan/ExamHeader.tsx
+++ b/src/components/cbt/kerjakan/ExamHeader.tsx
@@ -1,0 +1,57 @@
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Type, Clock, LayoutGrid } from "lucide-react";
+import { useExamContext } from "./ExamContext";
+
+export function ExamHeader() {
+  const { sesi, idx, remaining, fontSize, setFontSize, setShowList } = useExamContext();
+
+  const mm = Math.floor(remaining / 60000);
+  const ss = Math.floor((remaining % 60000) / 1000);
+  const danger = remaining < 300_000; // < 5 minutes
+  const critical = remaining < 60_000; // < 1 minute
+
+  return (
+    <div className="sticky top-0 z-20 bg-white/80 dark:bg-slate-900/80 backdrop-blur-xl border-b border-slate-200 dark:border-slate-800 px-4 sm:px-8 py-4 sm:py-5 flex items-center justify-between transition-colors">
+      <div className="flex items-center gap-4">
+        <div className="flex items-center justify-center w-12 h-12 rounded-2xl bg-primary/10 text-primary font-black text-xl border border-primary/20 shadow-sm">
+          {idx + 1}
+        </div>
+        <div className="hidden sm:block">
+          <p className="text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-0.5">Soal Ke-</p>
+          <p className="text-sm font-semibold text-slate-700 dark:text-slate-300 leading-none">Dari {sesi.soalIds.length} Soal</p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3 sm:gap-6">
+        <div className="hidden sm:flex items-center gap-1 bg-slate-100 dark:bg-slate-800 p-1 rounded-xl border border-slate-200 dark:border-slate-700/50">
+          <button onClick={() => setFontSize("sm")} className={cn("flex items-center justify-center w-8 h-8 rounded-lg font-bold text-sm transition-all", fontSize === "sm" ? "bg-white dark:bg-slate-700 text-primary shadow-sm" : "text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200")} title="Perkecil Teks">
+            <Type className="w-3.5 h-3.5" />
+          </button>
+          <button onClick={() => setFontSize("base")} className={cn("flex items-center justify-center w-8 h-8 rounded-lg font-bold text-base transition-all", fontSize === "base" ? "bg-white dark:bg-slate-700 text-primary shadow-sm" : "text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200")} title="Teks Normal">
+            <Type className="w-4 h-4" />
+          </button>
+          <button onClick={() => setFontSize("lg")} className={cn("flex items-center justify-center w-8 h-8 rounded-lg font-bold text-lg transition-all", fontSize === "lg" ? "bg-white dark:bg-slate-700 text-primary shadow-sm" : "text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200")} title="Perbesar Teks">
+            <Type className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className={cn(
+          "flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-1.5 sm:py-2 rounded-xl border shadow-sm transition-colors",
+          critical ? "bg-red-500 text-white border-red-600 animate-pulse" : 
+          danger ? "bg-red-50 dark:bg-red-950/30 text-red-600 dark:text-red-400 border-red-200 dark:border-red-900" : 
+          "bg-slate-50 dark:bg-slate-800 text-slate-700 dark:text-slate-200 border-slate-200 dark:border-slate-700"
+        )}>
+          <Clock className={cn("w-4 h-4 sm:w-5 sm:h-5", critical ? "text-white" : danger ? "text-red-500" : "text-slate-400")} />
+          <span className="font-mono font-bold text-base sm:text-lg tracking-tight tabular-nums mt-0.5">
+            {String(mm).padStart(2, "0")}:{String(ss).padStart(2, "0")}
+          </span>
+        </div>
+
+        <Button variant="outline" size="icon" className="md:hidden w-10 h-10 rounded-xl border-slate-200 dark:border-slate-700" onClick={() => setShowList(true)}>
+          <LayoutGrid className="w-5 h-5 text-slate-600 dark:text-slate-400" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/cbt/kerjakan/ExamMobileModal.tsx
+++ b/src/components/cbt/kerjakan/ExamMobileModal.tsx
@@ -1,0 +1,84 @@
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { LayoutGrid, X } from "lucide-react";
+import { useExamContext } from "./ExamContext";
+
+export function ExamMobileModal() {
+  const { sesi, idx, showList, setShowList, handleNavigateIdx, submit } = useExamContext();
+
+  if (!showList) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-slate-50/95 dark:bg-slate-950/95 backdrop-blur-md flex flex-col animate-in fade-in zoom-in-95 duration-200">
+      <div className="flex justify-between items-center bg-white dark:bg-slate-900 px-6 py-5 border-b border-slate-200 dark:border-slate-800 shadow-sm">
+        <div className="flex items-center gap-3 text-lg font-black text-slate-800 dark:text-white">
+          <LayoutGrid className="w-5 h-5 text-primary" /> DAFTAR SOAL
+        </div>
+        <button 
+          className="p-2 bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700 rounded-full transition-colors text-slate-600 dark:text-slate-300"
+          onClick={() => setShowList(false)}
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+      
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="max-w-xl mx-auto">
+          
+          <div className="flex justify-between items-center bg-white dark:bg-slate-900 p-4 rounded-2xl border border-slate-200 dark:border-slate-800 mb-8 shadow-sm">
+            <div className="flex flex-col items-center">
+              <div className="w-4 h-4 rounded-full bg-primary shadow-sm mb-1" />
+              <span className="text-xs font-semibold text-slate-500">Sudah</span>
+            </div>
+            <div className="flex flex-col items-center">
+              <div className="w-4 h-4 rounded-full bg-amber-400 shadow-sm mb-1" />
+              <span className="text-xs font-semibold text-slate-500">Ragu</span>
+            </div>
+            <div className="flex flex-col items-center">
+              <div className="w-4 h-4 rounded-full bg-white dark:bg-slate-800 border-2 border-slate-200 dark:border-slate-700 shadow-sm mb-1" />
+              <span className="text-xs font-semibold text-slate-500">Kosong</span>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-5 sm:grid-cols-6 gap-3">
+            {sesi.soalIds.map((_, i) => {
+              const a = sesi.jawaban[i];
+              const dijawab = a.jawabanIds.length > 0 || a.jawabanEssay.length > 0;
+              return (
+                <button
+                  key={i}
+                  onClick={() => { handleNavigateIdx(i); setShowList(false); }}
+                  className={cn(
+                    "relative aspect-square rounded-2xl text-lg font-bold border-2 transition-all shadow-sm active:scale-95",
+                    i === idx && "ring-4 ring-primary/30",
+                    a.ragu
+                      ? "bg-amber-400 text-white border-amber-500"
+                      : dijawab
+                        ? "bg-primary text-white border-primary"
+                        : "bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300 border-slate-200 dark:border-slate-700"
+                  )}
+                >
+                  {i + 1}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="mt-12 pb-12">
+            <Button 
+              size="lg"
+              variant="destructive"
+              className="w-full h-14 font-black text-lg uppercase tracking-widest shadow-lg"
+              onClick={() => {
+                setShowList(false);
+                if (confirm("Kumpulkan sekarang?")) void submit();
+              }}
+            >
+              Akhiri Ujian
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/cbt/kerjakan/ExamQuestion.tsx
+++ b/src/components/cbt/kerjakan/ExamQuestion.tsx
@@ -1,0 +1,113 @@
+import { cn } from "@/lib/utils";
+import { Textarea } from "@/components/ui/textarea";
+import { AudioPlayer } from "@/components/cbt/AudioPlayer";
+import { RichView } from "@/components/cbt/RichEditor";
+import { useExamContext } from "./ExamContext";
+import { soalRepo } from "@/lib/cbt/repos";
+
+export function ExamQuestion() {
+  const { sesi, idx, fontSize, updateJawaban, toggleOption } = useExamContext();
+
+  const soalId = sesi.soalIds[idx];
+  const soal = soalId ? soalRepo.byId(soalId) : undefined;
+  const currentJawaban = sesi.jawaban[idx];
+
+  if (!soal || !currentJawaban) {
+    return <div className="p-8 text-center font-medium">Soal bermasalah.</div>;
+  }
+
+  const optOrder = sesi.jawabanOrder[soal.id] ?? soal.jawaban.map((o) => o.id);
+
+  const textSizeClass = 
+    fontSize === "sm" ? "text-sm sm:text-base prose-sm" : 
+    fontSize === "lg" ? "text-xl sm:text-2xl prose-xl" : "text-base sm:text-lg prose-base";
+
+  return (
+    <div className="flex-1 overflow-y-auto overflow-x-hidden relative">
+      <div className="max-w-4xl mx-auto px-5 sm:px-10 py-8 sm:py-12 pb-32">
+        
+        {/* Question Text */}
+        <div className={cn("prose prose-slate dark:prose-invert max-w-none mb-10 text-slate-800 dark:text-slate-200 leading-loose", textSizeClass)}>
+          <RichView html={soal.detail} />
+        </div>
+        
+        {/* Audio Player if present */}
+        {soal.audioFileId && (
+          <div className="mb-10 bg-slate-50 dark:bg-slate-900/50 p-6 rounded-2xl border border-slate-200 dark:border-slate-800">
+            <p className="text-sm font-semibold text-slate-500 dark:text-slate-400 mb-4 uppercase tracking-widest">Audio Pendukung</p>
+            <AudioPlayer
+              fileId={soal.audioFileId}
+              playOnce={soal.audioPlayOnce}
+              storageKey={`cbtman:audio:${sesi.id}:${soal.id}`}
+            />
+          </div>
+        )}
+
+        {/* Options / Essay Input */}
+        <div className="space-y-4">
+          {soal.tipe === "essay" ? (
+            <div className="group relative">
+              <div className="absolute -inset-0.5 bg-gradient-to-r from-primary/50 to-primary opacity-0 group-focus-within:opacity-100 rounded-2xl blur transition duration-300" />
+              <Textarea
+                rows={10}
+                value={currentJawaban.jawabanEssay}
+                onChange={(e) => updateJawaban({ jawabanEssay: e.target.value })}
+                placeholder="Ketik jawaban esai Anda secara lengkap dan jelas di sini..."
+                className={cn(
+                  "relative bg-white dark:bg-slate-950 resize-y p-6 rounded-2xl border-2 border-slate-200 dark:border-slate-800 focus-visible:ring-0 focus-visible:border-primary shadow-inner transition-colors",
+                  textSizeClass
+                )}
+              />
+            </div>
+          ) : (
+            optOrder.map((oid, i) => {
+              const opt = soal.jawaban.find((x) => x.id === oid);
+              if (!opt) return null;
+              const isChecked = currentJawaban.jawabanIds.includes(oid);
+              const optLetter = String.fromCharCode(65 + i);
+
+              return (
+                <label 
+                  key={oid}
+                  className={cn(
+                    "group relative flex items-start p-4 sm:p-5 rounded-2xl border-2 cursor-pointer transition-all duration-200 hover:-translate-y-0.5",
+                    isChecked 
+                      ? "bg-primary/5 border-primary shadow-[0_0_0_1px_rgba(3,165,89,1)] dark:bg-primary/10 dark:shadow-[0_0_0_1px_rgba(3,165,89,0.5)]" 
+                      : "bg-white dark:bg-slate-950 border-slate-200 dark:border-slate-800 hover:border-slate-300 dark:hover:border-slate-700 hover:shadow-md"
+                  )}
+                >
+                  <input
+                    type={soal.tipe === "multi" ? "checkbox" : "radio"}
+                    name={`soal-${soal.id}`}
+                    className="sr-only"
+                    checked={isChecked}
+                    onChange={() => toggleOption(oid)}
+                  />
+                  
+                  <div className="flex shrink-0 items-center justify-center mt-0.5 sm:mt-1 mr-4 sm:mr-6">
+                    <div className={cn(
+                      "flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full border-2 font-bold transition-all duration-300",
+                      isChecked
+                        ? "bg-primary border-primary text-white scale-110 shadow-md"
+                        : "bg-slate-50 dark:bg-slate-900 border-slate-300 dark:border-slate-700 text-slate-500 dark:text-slate-400 group-hover:border-primary/50 group-hover:text-primary"
+                    )}>
+                      {optLetter}
+                    </div>
+                  </div>
+
+                  <div className={cn(
+                    "flex-1 min-w-0 prose prose-slate dark:prose-invert max-w-none prose-p:my-0 leading-relaxed transition-colors",
+                    textSizeClass,
+                    isChecked ? "text-slate-900 dark:text-white font-medium" : "text-slate-600 dark:text-slate-300"
+                  )}>
+                    <RichView html={opt.detail} />
+                  </div>
+                </label>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/cbt/kerjakan/ExamSidebar.tsx
+++ b/src/components/cbt/kerjakan/ExamSidebar.tsx
@@ -1,0 +1,69 @@
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { useExamContext } from "./ExamContext";
+
+export function ExamSidebar() {
+  const { sesi, idx, handleNavigateIdx, submit } = useExamContext();
+
+  return (
+    <div className="hidden md:flex flex-col w-80 bg-slate-50/50 dark:bg-slate-950/30 border-l border-slate-200 dark:border-slate-800">
+      <div className="p-6 border-b border-slate-200 dark:border-slate-800 bg-white/50 dark:bg-slate-900/50 backdrop-blur-sm">
+        <h3 className="font-extrabold text-slate-800 dark:text-slate-200 text-lg tracking-tight">Navigasi Soal</h3>
+        
+        <div className="mt-4 flex flex-col gap-2">
+          <div className="flex items-center gap-3 text-sm font-medium text-slate-600 dark:text-slate-400">
+            <div className="w-4 h-4 rounded-full bg-primary shadow-sm" /> Sudah Dijawab
+          </div>
+          <div className="flex items-center gap-3 text-sm font-medium text-slate-600 dark:text-slate-400">
+            <div className="w-4 h-4 rounded-full bg-amber-400 shadow-sm" /> Ragu-ragu
+          </div>
+          <div className="flex items-center gap-3 text-sm font-medium text-slate-600 dark:text-slate-400">
+            <div className="w-4 h-4 rounded-full bg-white dark:bg-slate-800 border-2 border-slate-200 dark:border-slate-700 shadow-sm" /> Belum Dijawab
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="grid grid-cols-5 gap-2.5">
+          {sesi.soalIds.map((_, i) => {
+            const a = sesi.jawaban[i];
+            const dijawab = a.jawabanIds.length > 0 || a.jawabanEssay.length > 0;
+            
+            return (
+              <button
+                key={i}
+                onClick={() => handleNavigateIdx(i)}
+                className={cn(
+                  "relative aspect-square flex items-center justify-center rounded-xl text-sm font-bold border-2 transition-all hover:scale-105",
+                  i === idx && "ring-4 ring-primary/20 dark:ring-primary/40",
+                  a.ragu
+                    ? "bg-amber-400 text-white border-amber-500 shadow-sm"
+                    : dijawab
+                      ? "bg-primary text-white border-primary shadow-sm"
+                      : "bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-400 border-slate-200 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-500"
+                )}
+              >
+                {i + 1}
+                {i === idx && (
+                  <span className="absolute -bottom-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-white dark:bg-slate-800 ring-2 ring-primary/20">
+                    <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="p-6 border-t border-slate-200 dark:border-slate-800 bg-white/50 dark:bg-slate-900/50 backdrop-blur-sm">
+        <Button
+          variant="destructive"
+          className="w-full h-12 font-bold uppercase tracking-widest shadow-md"
+          onClick={() => { if (confirm("Yakin ingin mengumpulkan?")) void submit(); }}
+        >
+          Akhiri Ujian
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/cbt/kerjakan/useExamState.ts
+++ b/src/components/cbt/kerjakan/useExamState.ts
@@ -1,0 +1,163 @@
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import { toast } from "sonner";
+import { useNavigate } from "@tanstack/react-router";
+import { soalRepo, sesiRepo } from "@/lib/cbt/repos";
+import { gradeSesi } from "@/lib/cbt/grading";
+import type { SesiUjian, Ujian } from "@/lib/cbt/types";
+
+export type FontSize = "sm" | "base" | "lg";
+
+export function useExamState(ujian: Ujian | undefined, user: { id: string } | null) {
+  const navigate = useNavigate();
+  
+  const [sesiDicari, setSesiDicari] = useState(false);
+  const [sesi, setSesi] = useState<SesiUjian | null>(null);
+  const [idx, setIdx] = useState(0);
+  const [now, setNow] = useState(Date.now());
+  const [showList, setShowList] = useState(false);
+  const [fontSize, setFontSize] = useState<FontSize>("base");
+
+  const submittingRef = useRef(false);
+  const saveTimer = useRef<NodeJS.Timeout | null>(null);
+  const sesiRef = useRef(sesi);
+
+  useEffect(() => {
+    sesiRef.current = sesi;
+  }, [sesi]);
+
+  useEffect(() => {
+    if (!user || !ujian) return;
+    const active = sesiRepo.all().find(
+      (x) => x.ujianId === ujian.id && x.pesertaId === user.id && x.status === "sedang"
+    );
+    setSesi(active || null);
+    setSesiDicari(true);
+  }, [user, ujian]);
+
+  useEffect(() => {
+    if (sesi && sesi.status === "selesai") {
+      navigate({
+        to: "/peserta/ujian/$id/hasil",
+        params: { id: sesi.ujianId },
+      });
+    }
+  }, [sesi, navigate]);
+
+  const endsAt = useMemo(() => {
+    if (!sesi || !ujian) return 0;
+    if (sesi.endsAt) return sesi.endsAt;
+    const start = sesi.mulaiAt || Date.now();
+    return start + (ujian.durasiMenit || 60) * 60 * 1000;
+  }, [sesi, ujian]);
+
+  const submit = useCallback(async (reason?: string) => {
+    if (submittingRef.current || !ujian || !sesiRef.current) return;
+    submittingRef.current = true;
+    try {
+      if (saveTimer.current) {
+        clearTimeout(saveTimer.current);
+        saveTimer.current = null;
+      }
+      const graded = gradeSesi(sesiRef.current, ujian);
+      sesiRepo.upsert(graded);
+      const result = await sesiRepo.flush();
+      if (!result.ok) {
+        toast.error("Gagal menyimpan jawaban. Coba kumpulkan lagi.");
+        submittingRef.current = false;
+        return;
+      }
+      if (document.fullscreenElement) document.exitFullscreen().catch(() => {});
+      toast.success(
+        reason ? `Ujian disubmit (${reason})` : "Ujian berhasil disubmit",
+      );
+      navigate({
+        to: "/peserta/ujian/$id/hasil",
+        params: { id: ujian.id },
+      });
+    } catch {
+      toast.error("Gagal menyimpan jawaban. Coba kumpulkan lagi.");
+      submittingRef.current = false;
+    }
+  }, [ujian, navigate]);
+
+  useEffect(() => {
+    if (!sesi || !ujian || sesi.status === "selesai") return;
+    const interval = setInterval(() => {
+      const n = Date.now();
+      setNow(n);
+      if (n >= endsAt) {
+        clearInterval(interval);
+        submit("Waktu Habis");
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [sesi, ujian, endsAt, submit]);
+
+  const updateJawaban = useCallback((partial: Partial<SesiUjian["jawaban"][0]>) => {
+    if (!sesi) return;
+    const nextSesi = { ...sesi };
+    nextSesi.jawaban = [...nextSesi.jawaban];
+    nextSesi.jawaban[idx] = { ...nextSesi.jawaban[idx], ...partial };
+    setSesi(nextSesi);
+
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => {
+      sesiRepo.upsert(nextSesi);
+      sesiRepo.flush();
+    }, 2000);
+  }, [sesi, idx]);
+
+  const toggleOption = useCallback((jawabanId: string) => {
+    if (!sesi) return;
+    const soalId = sesi.soalIds[idx];
+    const soal = soalId ? soalRepo.byId(soalId) : undefined;
+    if (!soal) return;
+
+    const currentJawaban = sesi.jawaban[idx];
+    let nextJawabanIds = [...currentJawaban.jawabanIds];
+
+    if (soal.tipe === "multi") {
+      const has = currentJawaban.jawabanIds.includes(jawabanId);
+      nextJawabanIds = has
+        ? currentJawaban.jawabanIds.filter((x) => x !== jawabanId)
+        : [...currentJawaban.jawabanIds, jawabanId];
+    } else {
+      nextJawabanIds = [jawabanId];
+    }
+
+    updateJawaban({ jawabanIds: nextJawabanIds });
+  }, [sesi, idx, updateJawaban]);
+
+  const handleNavigateIdx = useCallback((newIdx: number) => {
+    if (!sesi) return;
+    const currentJawaban = sesi.jawaban[idx];
+    
+    if (newIdx !== idx) {
+      const dijawab = currentJawaban.jawabanIds.length > 0 || currentJawaban.jawabanEssay.trim().length > 0;
+      if (!dijawab) {
+        toast.error("Silakan pilih atau isi jawaban terlebih dahulu.");
+        return;
+      }
+    }
+    
+    setIdx(newIdx);
+  }, [sesi, idx]);
+
+  const remaining = Math.max(0, endsAt - now);
+
+  return {
+    sesiDicari,
+    sesi,
+    idx,
+    now,
+    remaining,
+    showList,
+    setShowList,
+    fontSize,
+    setFontSize,
+    updateJawaban,
+    toggleOption,
+    handleNavigateIdx,
+    submit
+  };
+}

--- a/src/components/cbt/landing/ExamScheduleTable.tsx
+++ b/src/components/cbt/landing/ExamScheduleTable.tsx
@@ -8,9 +8,10 @@ import {
 } from "@/components/ui/table";
 import { CalendarDays, GraduationCap, Clock, Timer } from "lucide-react";
 import { getExamCountdown, getExamStatus } from "@/lib/cbt/time";
+import { type Ujian } from "@/lib/cbt/types";
 
 interface ExamScheduleTableProps {
-  exams: any[];
+  exams: Ujian[];
   activeTab: "online" | "offline";
   groupsMap: Record<string, string>;
   now: number;

--- a/src/components/cbt/landing/ExamScheduleTable.tsx
+++ b/src/components/cbt/landing/ExamScheduleTable.tsx
@@ -1,0 +1,145 @@
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from "@/components/ui/table";
+import { CalendarDays, GraduationCap, Clock, Timer } from "lucide-react";
+import { getExamCountdown, getExamStatus } from "@/lib/cbt/time";
+
+interface ExamScheduleTableProps {
+  exams: any[];
+  activeTab: "online" | "offline";
+  groupsMap: Record<string, string>;
+  now: number;
+}
+
+export function ExamScheduleTable({ exams, activeTab, groupsMap, now }: ExamScheduleTableProps) {
+  return (
+    <div className="border border-white/50 dark:border-white/10 rounded-2xl bg-white/40 dark:bg-black/20 shadow-[inset_0_1px_1px_rgba(255,255,255,0.4)] dark:shadow-[inset_0_1px_1px_rgba(255,255,255,0.05)] backdrop-blur-md relative z-10 overflow-y-auto overflow-x-auto max-h-[250px] custom-scrollbar">
+      <Table>
+        <TableHeader className="bg-white/60 dark:bg-white/5 border-b border-slate-200/50 dark:border-white/10">
+          <TableRow className="hover:bg-transparent border-none">
+            <TableHead className="w-16 text-center font-sans font-extrabold text-xs uppercase tracking-wider py-4 text-slate-500 dark:text-slate-400">
+              No
+            </TableHead>
+            <TableHead className="font-sans font-extrabold text-xs uppercase tracking-wider py-4 text-slate-500 dark:text-slate-400">
+              Nama Ujian
+            </TableHead>
+            <TableHead className="font-sans font-extrabold text-xs uppercase tracking-wider py-4 text-slate-500 dark:text-slate-400">
+              Program Studi
+            </TableHead>
+            <TableHead className="font-sans font-extrabold text-xs uppercase tracking-wider py-4 text-slate-500 dark:text-slate-400">
+              Waktu
+            </TableHead>
+            <TableHead className="text-center font-sans font-extrabold text-xs uppercase tracking-wider py-4 text-slate-500 dark:text-slate-400">
+              Durasi
+            </TableHead>
+            <TableHead className="text-center font-sans font-extrabold text-xs uppercase tracking-wider py-4 text-slate-500 dark:text-slate-400">
+              Countdown
+            </TableHead>
+            <TableHead className="text-right font-sans font-extrabold text-xs uppercase tracking-wider py-4 pr-6 text-slate-500 dark:text-slate-400">
+              Status
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {exams.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={7}
+                className="p-12 text-center text-slate-500 dark:text-slate-400 font-medium"
+              >
+                <div className="flex flex-col items-center gap-3">
+                  <div className="h-12 w-12 rounded-full bg-slate-100 dark:bg-white/5 flex items-center justify-center">
+                    <CalendarDays className="h-6 w-6 opacity-50" />
+                  </div>
+                  <p>Tidak ada ujian {activeTab === "online" ? "online" : "offline"} yang dijadwalkan hari ini.</p>
+                </div>
+              </TableCell>
+            </TableRow>
+          ) : (
+            exams.map((exam, index) => (
+              <TableRow
+                key={exam.id}
+                className="transition-colors border-b border-slate-200/50 dark:border-white/5 group"
+              >
+                <TableCell className="text-center font-bold text-slate-400 dark:text-slate-500 py-4">
+                  {String(index + 1).padStart(2, '0')}
+                </TableCell>
+                <TableCell className="font-bold text-slate-800 dark:text-slate-100 py-4 transition-colors">
+                  {exam.nama}
+                </TableCell>
+                <TableCell className="py-4">
+                  <span className="inline-flex items-center gap-1.5 rounded-md bg-white/60 dark:bg-black/30 px-2.5 py-1 text-xs font-bold text-slate-600 dark:text-slate-300 shadow-sm border border-slate-200/50 dark:border-white/5">
+                    <GraduationCap className="h-3.5 w-3.5 text-[#03A559]" />
+                    {exam.groupIds[0] && groupsMap[exam.groupIds[0]] ? groupsMap[exam.groupIds[0]] : "—"}
+                  </span>
+                </TableCell>
+                <TableCell className="text-slate-600 dark:text-slate-300 font-bold text-sm py-4">
+                  <span suppressHydrationWarning className="flex items-center gap-2">
+                    <Clock className="h-4 w-4 text-blue-500" />
+                    {exam.beginAt
+                      ? new Date(Number(exam.beginAt)).toLocaleTimeString(
+                          "id-ID",
+                          { hour: "2-digit", minute: "2-digit" },
+                        )
+                      : "—"}{" "}
+                    —
+                    {exam.endAt
+                      ? new Date(Number(exam.endAt)).toLocaleTimeString(
+                          "id-ID",
+                          { hour: "2-digit", minute: "2-digit" },
+                        )
+                      : "—"}
+                  </span>
+                </TableCell>
+                <TableCell className="text-center py-4">
+                  <span className="inline-flex items-center gap-1.5 bg-green-50 dark:bg-green-500/10 px-2.5 py-1 rounded-md text-green-600 dark:text-green-300 text-xs font-bold border border-green-100 dark:border-green-500/20">
+                    <Timer className="h-3.5 w-3.5" />
+                    {exam.durasiMenit} mnt
+                  </span>
+                </TableCell>
+                <TableCell className="text-center py-4">
+                  {(() => {
+                    const countdown = getExamCountdown(exam.beginAt, exam.endAt, now);
+                    return (
+                      <span className={`inline-flex items-center text-sm font-bold tracking-wider ${countdown.color}`}>
+                        {countdown.text}
+                      </span>
+                    );
+                  })()}
+                </TableCell>
+                <TableCell className="text-right pr-6 py-4">
+                  {(() => {
+                    const status = getExamStatus(exam.beginAt, exam.endAt, now);
+                    let colorClasses = "";
+                    if (status.text === "Ujian Sudah Berlalu") {
+                      colorClasses =
+                        "bg-red-50 text-red-600 border-red-200 dark:bg-red-500/10 dark:text-red-400 dark:border-red-500/20";
+                    } else if (
+                      status.text === "Ujian Sedang Berlangsung"
+                    ) {
+                      colorClasses =
+                        "bg-green-50 text-green-600 border-green-200 dark:bg-green-500/10 dark:text-green-400 dark:border-green-500/20 animate-pulse shadow-[0_0_10px_rgba(34,197,94,0.2)]";
+                    } else {
+                      colorClasses =
+                        "bg-amber-50 text-amber-600 border-amber-200 dark:bg-amber-500/10 dark:text-amber-400 dark:border-amber-500/20";
+                    }
+                    return (
+                      <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-extrabold border whitespace-nowrap ${colorClasses}`}>
+                        {status.text}
+                      </span>
+                    );
+                  })()}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/cbt/landing/ExamTabs.tsx
+++ b/src/components/cbt/landing/ExamTabs.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@/lib/utils";
+import { Globe, Monitor } from "lucide-react";
+
+interface ExamTabsProps {
+  activeTab: "online" | "offline";
+  setActiveTab: (tab: "online" | "offline") => void;
+  onlineCount: number;
+  offlineCount: number;
+}
+
+export function ExamTabs({ activeTab, setActiveTab, onlineCount, offlineCount }: ExamTabsProps) {
+  return (
+    <div className="relative grid grid-cols-2 bg-slate-200/50 dark:bg-black/20 p-1.5 rounded-xl border border-slate-300/50 dark:border-white/5 w-full sm:w-[320px]">
+      <div
+        className={cn(
+          "absolute top-1.5 bottom-1.5 left-1.5 w-[calc(50%-6px)] bg-white dark:bg-slate-800 rounded-lg shadow-sm transition-transform duration-300 ease-out z-0",
+          activeTab === "online" ? "translate-x-0" : "translate-x-full"
+        )}
+      />
+
+      <button
+        className={cn(
+          "relative z-10 flex items-center justify-center gap-2 px-2 py-2.5 text-sm font-bold rounded-lg transition-colors duration-300",
+          activeTab === "online"
+            ? "text-[#03A559] dark:text-green-400"
+            : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+        )}
+        onClick={() => setActiveTab("online")}
+      >
+        <Globe className="h-4 w-4" /> Online 
+        <span className={cn(
+          "px-1.5 py-0.5 rounded-md text-xs transition-colors duration-300",
+          activeTab === "online" ? "bg-slate-100 dark:bg-slate-900" : "bg-white/50 dark:bg-black/10"
+        )}>
+          {onlineCount}
+        </span>
+      </button>
+
+      <button
+        className={cn(
+          "relative z-10 flex items-center justify-center gap-2 px-2 py-2.5 text-sm font-bold rounded-lg transition-colors duration-300",
+          activeTab === "offline"
+            ? "text-[#03A559] dark:text-green-400"
+            : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+        )}
+        onClick={() => setActiveTab("offline")}
+      >
+        <Monitor className="h-4 w-4" /> Offline
+        <span className={cn(
+          "px-1.5 py-0.5 rounded-md text-xs transition-colors duration-300",
+          activeTab === "offline" ? "bg-slate-100 dark:bg-slate-900" : "bg-white/50 dark:bg-black/10"
+        )}>
+          {offlineCount}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/src/lib/cbt/grading.ts
+++ b/src/lib/cbt/grading.ts
@@ -1,0 +1,43 @@
+import { soalRepo } from "./repos";
+import type { SesiUjian, Ujian } from "./types";
+
+export function gradeSesi(sesi: SesiUjian, ujian: Ujian): SesiUjian {
+  const currentSesi = JSON.parse(JSON.stringify(sesi)) as SesiUjian;
+  let score = 0;
+  
+  for (let i = 0; i < currentSesi.soalIds.length; i++) {
+    const soalId = currentSesi.soalIds[i];
+    const soal = soalRepo.byId(soalId);
+    const j = currentSesi.jawaban[i];
+    if (!soal || !j) continue;
+
+    if (soal.tipe === "multi") {
+      const correctIds = soal.jawaban.filter((x) => x.benar).map((x) => x.id);
+      const isCorrect =
+        j.jawabanIds.length === correctIds.length &&
+        j.jawabanIds.every((id) => correctIds.includes(id));
+      if (isCorrect) score += ujian.poinBenar;
+    } else {
+      const correctOpt = soal.jawaban.find((x) => x.benar);
+      if (correctOpt && j.jawabanIds.includes(correctOpt.id)) {
+        score += ujian.poinBenar;
+      }
+    }
+  }
+  
+  currentSesi.status = "selesai";
+  currentSesi.skorTotal = score;
+  currentSesi.selesaiAt = Date.now();
+  
+  if (currentSesi.mulaiAt) {
+    const maxDur = ujian.durasiMenit || 60;
+    const start = currentSesi.mulaiAt;
+    const now = Date.now();
+    const elapsedMinutes = (now - start) / 60000;
+    if (elapsedMinutes > maxDur + 5) {
+      currentSesi.selesaiAt = start + maxDur * 60000;
+    }
+  }
+
+  return currentSesi;
+}

--- a/src/lib/cbt/time.ts
+++ b/src/lib/cbt/time.ts
@@ -1,0 +1,71 @@
+export function getExamStatus(beginAt: number | undefined, endAt: number | undefined, now: number) {
+  if (!beginAt || !endAt) return { text: "Belum Ditentukan", color: "text-slate-500" };
+
+  if (now > endAt) {
+    return {
+      text: "Ujian Sudah Berlalu",
+      color:
+        "bg-red-500/10 text-red-600 dark:text-red-400 border-red-200/50 dark:border-red-900/30",
+    };
+  } else if (now >= beginAt && now <= endAt) {
+    return {
+      text: "Ujian Sedang Berlangsung",
+      color:
+        "bg-green-500/10 text-green-600 dark:text-green-400 border-green-200/50 dark:border-green-900/30",
+    };
+  } else {
+    return {
+      text: "Ujian Akan Berlangsung",
+      color:
+        "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-200/50 dark:border-amber-900/30",
+    };
+  }
+}
+
+export function getExamCountdown(beginAt: number | undefined, endAt: number | undefined, now: number) {
+  if (!beginAt || !endAt) return { text: "—", color: "text-slate-400 dark:text-slate-500 font-medium" };
+
+  if (now > endAt) {
+    return {
+      text: "—",
+      color: "text-slate-400 dark:text-slate-500 font-medium",
+    };
+  } else if (now >= beginAt && now <= endAt) {
+    const diffSeconds = Math.floor((endAt - now) / 1000);
+    const hours = Math.floor(diffSeconds / 3600);
+    const minutes = Math.floor((diffSeconds % 3600) / 60);
+    const seconds = diffSeconds % 60;
+
+    const formatted = [
+      hours > 0 ? String(hours).padStart(2, "0") : null,
+      String(minutes).padStart(2, "0"),
+      String(seconds).padStart(2, "0"),
+    ]
+      .filter(Boolean)
+      .join(":");
+
+    return {
+      text: `${formatted} (Sisa)`,
+      color:
+        "text-green-600 dark:text-green-400 font-bold font-mono animate-pulse",
+    };
+  } else {
+    const diffSeconds = Math.floor((beginAt - now) / 1000);
+    const hours = Math.floor(diffSeconds / 3600);
+    const minutes = Math.floor((diffSeconds % 3600) / 60);
+    const seconds = diffSeconds % 60;
+
+    const formatted = [
+      hours > 0 ? String(hours).padStart(2, "0") : null,
+      String(minutes).padStart(2, "0"),
+      String(seconds).padStart(2, "0"),
+    ]
+      .filter(Boolean)
+      .join(":");
+
+    return {
+      text: `${formatted} (Mulai)`,
+      color: "text-amber-600 dark:text-amber-400 font-bold font-mono",
+    };
+  }
+}

--- a/src/routes/_authenticated/admin.akademik.tsx
+++ b/src/routes/_authenticated/admin.akademik.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Link, Outlet, useLocation } from "@tanstack/react-router";
 import { cn } from "@/lib/utils";
-import { Building2, GraduationCap, Library, Network, Calendar, Clock, BookOpen, ChevronRight } from "lucide-react";
-import { AdminPage, AdminPageHeader } from "@/components/cbt/AdminPage";
+import { Building2, GraduationCap, Library, Network, Calendar, Clock, BookOpen, ChevronRight, Info } from "lucide-react";
 
 export const Route = createFileRoute("/_authenticated/admin/akademik")({
   component: AkademikLayout,
@@ -35,74 +34,83 @@ function AkademikLayout() {
   const { pathname } = useLocation();
 
   return (
-    <AdminPage className="max-w-6xl">
-      <AdminPageHeader
-        title="Data Akademik"
-        description="Kelola data induk institusi. Data ini disusun dalam bentuk hierarki pohon (Tree Structure)."
-      />
+    <div className="relative min-h-screen pb-24">
+      {/* Studio-Tier Glow */}
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-indigo-50/40 via-white to-white dark:from-indigo-950/20 dark:via-zinc-950 dark:to-zinc-950 -z-10" />
 
-      {/* Info Alert */}
-      <div className="mb-8 p-4 rounded-xl border border-blue-200 dark:border-blue-900/50 bg-blue-50/50 dark:bg-blue-950/20 text-sm text-blue-800 dark:text-blue-300 flex items-start gap-3">
-        <Network className="w-5 h-5 shrink-0 mt-0.5 text-blue-600 dark:text-blue-400" />
-        <div>
-          <strong className="font-semibold block text-blue-900 dark:text-blue-200">Struktur Hierarki (Tree)</strong>
-          <p className="mt-1">
-            Data akademik saling terikat secara vertikal ke bawah. Anda harus membuat tingkat tertinggi (Fakultas) terlebih dahulu sebelum dapat membuat turunannya (Jurusan & Program Studi).
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-12 space-y-12">
+        {/* Header */}
+        <div className="space-y-4">
+          <h1 className="text-4xl md:text-5xl font-black tracking-tighter text-slate-900 dark:text-zinc-50">
+            Data Akademik
+          </h1>
+          <p className="text-base text-slate-500 dark:text-zinc-400 font-medium max-w-2xl leading-relaxed">
+            Kelola data induk institusi. Konfigurasi di sini akan menjadi fondasi bagi pengelolaan mahasiswa, dosen, dan mata kuliah.
           </p>
         </div>
-      </div>
 
-      <div className="flex flex-col md:flex-row gap-8 items-start">
-        
-        {/* Tree Sidebar */}
-        <aside className="w-full md:w-64 shrink-0 space-y-6">
-          {TREE_MENU.map((group, idx) => (
-            <div key={idx} className="space-y-2">
-              <h4 className="text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 px-2">
-                {group.section}
-              </h4>
-              <nav className="flex flex-col relative">
-                {/* Continuous vertical line for the tree branch */}
-                {group.section === "Struktur Institusi" && (
-                  <div className="absolute left-6 top-6 bottom-6 w-px bg-slate-200 dark:bg-slate-700/60 z-0" />
-                )}
-                
-                {group.items.map((item) => {
-                  const active = pathname.startsWith(item.to);
-                  const Icon = item.icon;
-                  return (
-                    <Link
-                      key={item.to}
-                      to={item.to}
-                      className={cn(
-                        "group relative z-10 flex items-center justify-between px-3 py-2.5 text-sm font-medium rounded-lg transition-all",
-                        active
-                          ? "bg-primary/10 text-primary dark:text-primary"
-                          : "text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800/50 hover:text-slate-900 dark:hover:text-slate-200"
-                      )}
-                      style={{ marginLeft: `${item.indent * 16}px` }}
-                    >
-                      <div className="flex items-center gap-3">
-                        {item.indent > 0 && (
-                          <div className="absolute left-[-10px] w-3 border-t-2 border-slate-200 dark:border-slate-700 rounded-bl-sm" />
+        {/* Info Alert - Studio Tier */}
+        <div className="rounded-2xl border border-indigo-200/60 dark:border-indigo-500/20 bg-indigo-50/50 dark:bg-indigo-500/10 p-5 flex gap-4 items-start shadow-sm">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-500/20 text-indigo-600 dark:text-indigo-400">
+            <Info className="h-5 w-5" />
+          </div>
+          <div>
+            <h3 className="font-bold text-indigo-900 dark:text-indigo-200">Struktur Hierarki</h3>
+            <p className="mt-1 text-sm text-indigo-700/80 dark:text-indigo-300/80 font-medium leading-relaxed">
+              Data akademik saling terikat secara vertikal. Anda harus membuat tingkat tertinggi (Fakultas) terlebih dahulu sebelum dapat menambahkan turunannya (Jurusan & Program Studi).
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col lg:flex-row gap-10 items-start">
+          
+          {/* Sidebar Navigation */}
+          <aside className="w-full lg:w-72 shrink-0 space-y-8">
+            {TREE_MENU.map((group, idx) => (
+              <div key={idx} className="space-y-3">
+                <h4 className="text-xs font-black uppercase tracking-widest text-slate-400 dark:text-zinc-500 px-1">
+                  {group.section}
+                </h4>
+                <nav className="flex flex-col space-y-1">
+                  {group.items.map((item) => {
+                    const active = pathname.startsWith(item.to);
+                    const Icon = item.icon;
+                    return (
+                      <Link
+                        key={item.to}
+                        to={item.to}
+                        className={cn(
+                          "group flex items-center justify-between px-3 py-2.5 text-sm font-semibold rounded-xl transition-all duration-200",
+                          active
+                            ? "bg-slate-900 text-white dark:bg-zinc-100 dark:text-zinc-900 shadow-md shadow-slate-900/10"
+                            : "text-slate-600 dark:text-zinc-400 hover:bg-slate-100 dark:hover:bg-zinc-800/60 hover:text-slate-900 dark:hover:text-zinc-100"
                         )}
-                        <Icon className={cn("w-4 h-4 shrink-0", active ? "text-primary" : "text-slate-400 group-hover:text-slate-600 dark:group-hover:text-slate-300")} />
-                        {item.label}
-                      </div>
-                      {active && <ChevronRight className="w-3.5 h-3.5 opacity-50" />}
-                    </Link>
-                  );
-                })}
-              </nav>
-            </div>
-          ))}
-        </aside>
+                        style={{ marginLeft: `${item.indent * 12}px` }}
+                      >
+                        <div className="flex items-center gap-3">
+                          <Icon className={cn(
+                            "w-4 h-4 shrink-0 transition-colors", 
+                            active ? "text-white/80 dark:text-zinc-900/80" : "text-slate-400 group-hover:text-slate-600 dark:group-hover:text-zinc-300"
+                          )} />
+                          {item.label}
+                        </div>
+                        {active && <ChevronRight className="w-4 h-4 opacity-70" />}
+                      </Link>
+                    );
+                  })}
+                </nav>
+              </div>
+            ))}
+          </aside>
 
-        {/* Content Outlet */}
-        <main className="flex-1 w-full bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-sm min-h-[500px] p-6 lg:p-8">
-          <Outlet />
-        </main>
+          {/* Content Outlet */}
+          <main className="flex-1 w-full bg-white/80 dark:bg-zinc-900/40 backdrop-blur-xl rounded-3xl border border-slate-200/80 dark:border-zinc-800/80 shadow-sm min-h-[600px] overflow-hidden">
+            <div className="p-6 md:p-8">
+              <Outlet />
+            </div>
+          </main>
+        </div>
       </div>
-    </AdminPage>
+    </div>
   );
 }

--- a/src/routes/_authenticated/admin.analitik.$id.tsx
+++ b/src/routes/_authenticated/admin.analitik.$id.tsx
@@ -144,8 +144,8 @@ function DaftarPesertaTab({ ujian, sesis, refresh }: { ujian: Ujian, sesis: Sesi
                   const isOpen = openId === s.id;
                   return (
                     <tr key={s.id} className={`border-b last:border-0 transition-colors ${isOpen ? 'bg-primary/5' : 'hover:bg-muted/30'}`}>
-                      <td className="p-4 font-medium">{u?.namaLengkap ?? s.pesertaId}</td>
-                      <td className="p-4">
+                      <td className="p-4 font-medium text-center border-r border-slate-200 dark:border-slate-800">{u?.namaLengkap ?? s.pesertaId}</td>
+                      <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
                         <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold ${
                           s.status === 'selesai' ? 'bg-success/15 text-success' :
                           s.status === 'sedang' ? 'bg-primary/15 text-primary' :
@@ -154,15 +154,15 @@ function DaftarPesertaTab({ ujian, sesis, refresh }: { ujian: Ujian, sesis: Sesi
                           {s.status}
                         </span>
                       </td>
-                      <td className="p-4 text-muted-foreground">
+                      <td className="p-4 text-muted-foreground text-center border-r border-slate-200 dark:border-slate-800">
                         {s.mulaiAt ? new Date(s.mulaiAt).toLocaleString("id-ID") : "-"}
                       </td>
-                      <td className="p-4">
+                      <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
                         {s.status === "selesai" ? (
                           <span className="font-bold text-base">{s.skorTotal ?? 0} <span className="text-xs text-muted-foreground font-normal">/ {s.maxSkor ?? 0}</span></span>
                         ) : "-"}
                       </td>
-                      <td className="p-4">
+                      <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
                         {s.pelanggaran > 0 ? (
                           <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-destructive/15 text-destructive">
                             {s.pelanggaran} peringatan
@@ -171,7 +171,7 @@ function DaftarPesertaTab({ ujian, sesis, refresh }: { ujian: Ujian, sesis: Sesi
                           <span className="text-muted-foreground">-</span>
                         )}
                       </td>
-                      <td className="p-4 text-right space-x-2">
+                      <td className="p-4 text-center space-x-2">
                         <Button size="sm" variant={isOpen ? "default" : "outline"} onClick={() => { setOpenId(isOpen ? null : s.id); setEditIdx(null); }}>
                           {isOpen ? "Tutup Lembar" : "Koreksi Lembar"}
                         </Button>

--- a/src/routes/_authenticated/admin.analitik.$id.tsx
+++ b/src/routes/_authenticated/admin.analitik.$id.tsx
@@ -155,7 +155,11 @@ function DaftarPesertaTab({ ujian, sesis, refresh }: { ujian: Ujian, sesis: Sesi
                         </span>
                       </td>
                       <td className="p-4 text-muted-foreground text-center border-r border-slate-200 dark:border-slate-800">
-                        {s.mulaiAt ? new Date(s.mulaiAt).toLocaleString("id-ID") : "-"}
+                        {s.mulaiAt ? (
+                          <span suppressHydrationWarning>
+                            {new Date(s.mulaiAt).toLocaleString("id-ID")}
+                          </span>
+                        ) : "-"}
                       </td>
                       <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
                         {s.status === "selesai" ? (

--- a/src/routes/_authenticated/admin.analitik.$id.tsx
+++ b/src/routes/_authenticated/admin.analitik.$id.tsx
@@ -128,7 +128,7 @@ function DaftarPesertaTab({ ujian, sesis, refresh }: { ujian: Ujian, sesis: Sesi
         <CardContent className="p-0">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
-              <thead className="bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-100 font-semibold border-b">
+              <thead className="bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-100 font-semibold">
                 <tr>
                   <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center border-r border-slate-200 dark:border-slate-800">Peserta</th>
                   <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center border-r border-slate-200 dark:border-slate-800">Status</th>
@@ -143,7 +143,7 @@ function DaftarPesertaTab({ ujian, sesis, refresh }: { ujian: Ujian, sesis: Sesi
                   const u = users.find((x) => x.id === s.pesertaId);
                   const isOpen = openId === s.id;
                   return (
-                    <tr key={s.id} className={`border-b last:border-0 transition-colors ${isOpen ? 'bg-primary/5' : 'hover:bg-muted/30'}`}>
+                    <tr key={s.id} className={`transition-colors ${isOpen ? 'bg-primary/5' : 'hover:bg-muted/30'}`}>
                       <td className="p-4 font-medium text-center border-r border-slate-200 dark:border-slate-800">{u?.namaLengkap ?? s.pesertaId}</td>
                       <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
                         <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold ${

--- a/src/routes/_authenticated/admin.modul.tsx
+++ b/src/routes/_authenticated/admin.modul.tsx
@@ -207,8 +207,8 @@ function ModulPage() {
         )}
       </div>
 
-      <AdminPageContent>
-        <div className="flex flex-col divide-y divide-slate-100 dark:divide-slate-800">
+            <AdminPageContent className="bg-transparent border-0 p-0 shadow-none">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {shown.map((m) => {
             const tAll = topikRepo.all().filter((t) => t.modulId === m.id);
             const t = allowedSet ? tAll.filter((x) => allowedSet.has(x.id)) : tAll;
@@ -217,51 +217,51 @@ function ModulPage() {
             const mkName = m.mataKuliahId ? mkList.find((x) => x.id === m.mataKuliahId)?.nama : null;
 
             return (
-              <div key={m.id} className="group flex flex-col sm:flex-row sm:items-center justify-between p-4 sm:px-6 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors gap-4">
-                
-                <div className="flex items-center gap-4">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400">
-                    <FileText className="h-5 w-5" />
+              <div key={m.id} className="group relative flex flex-col justify-between p-5 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 hover:border-blue-300 dark:hover:border-blue-800 hover:shadow-md transition-all gap-4 overflow-hidden">
+                <div className="flex items-start gap-4">
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 group-hover:bg-blue-100 dark:group-hover:bg-blue-900/40 transition-colors">
+                    <FileText className="h-6 w-6" />
                   </div>
-                  <div className="flex-1 min-w-0 space-y-1">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <Link to="/admin/modul/$id/topik" params={{ id: m.id }} className="text-sm font-semibold text-slate-900 dark:text-slate-100 hover:text-primary transition-colors truncate">
-                        {m.nama}
-                      </Link>
-                      {mkName && (
+                  <div className="flex-1 min-w-0 space-y-2 pt-1">
+                    <Link to="/admin/modul/$id/topik" params={{ id: m.id }} className="text-base font-semibold text-slate-900 dark:text-slate-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors line-clamp-2 after:absolute after:inset-0">
+                      {m.nama}
+                    </Link>
+                    {mkName && (
+                      <div className="relative z-10">
                         <span className="px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 text-[10px] font-semibold tracking-wide uppercase text-slate-500">
                           {mkName}
                         </span>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-4 text-xs font-medium text-slate-500 mt-1">
-                      <span className="flex items-center gap-1.5"><FileText className="w-3.5 h-3.5 text-slate-400"/> {t.length} Topik</span>
-                      <span className="flex items-center gap-1.5"><ChevronRight className="w-3.5 h-3.5 text-slate-400"/> {sCount} Soal</span>
-                    </div>
+                      </div>
+                    )}
                   </div>
                 </div>
 
-                <div className="flex items-center gap-2 opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
-                  <Button size="sm" variant="outline" className="h-8 shadow-sm bg-white dark:bg-slate-900" onClick={() => exportBank(m)} title="Export JSON">
-                    <Download className="mr-2 h-3.5 w-3.5" /> Export
-                  </Button>
-                  {canEdit && (
-                    <Button size="sm" variant="ghost" className="h-8 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950" onClick={() => remove(m.id)}>
-                      <Trash2 className="h-4 w-4" />
+                <div className="flex items-center justify-between mt-2 pt-4 border-t border-slate-100 dark:border-slate-800/60">
+                  <div className="flex items-center gap-4 text-xs font-medium text-slate-500">
+                    <span className="flex items-center gap-1.5"><FileText className="w-4 h-4 text-slate-400"/> {t.length} Topik</span>
+                    <span className="flex items-center gap-1.5"><ChevronRight className="w-4 h-4 text-slate-400"/> {sCount} Soal</span>
+                  </div>
+
+                  <div className="flex items-center gap-1 relative z-10">
+                    <Button size="icon" variant="ghost" className="h-8 w-8 text-slate-400 hover:text-slate-900 dark:hover:text-slate-100" onClick={() => exportBank(m)} title="Export JSON">
+                      <Download className="h-4 w-4" />
                     </Button>
-                  )}
-                  <Button size="sm" className="h-8 shadow-sm" asChild>
-                    <Link to="/admin/modul/$id/topik" params={{ id: m.id }}>
-                      Kelola Topik
-                    </Link>
-                  </Button>
+                    {canEdit && (
+                      <Button size="icon" variant="ghost" className="h-8 w-8 text-slate-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30 dark:hover:text-red-400" onClick={() => remove(m.id)} title="Hapus">
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    )}
+                  </div>
                 </div>
               </div>
             );
           })}
           {shown.length === 0 && (
-            <div className="p-8 text-center text-slate-500 text-sm">
-              Belum ada modul bank soal.
+            <div className="col-span-full p-12 text-center border-2 border-dashed border-slate-200 dark:border-slate-800 rounded-xl">
+              <div className="flex flex-col items-center justify-center gap-2 text-slate-500">
+                <FileText className="h-8 w-8 text-slate-300" />
+                <p className="text-sm font-medium">Belum ada modul bank soal.</p>
+              </div>
             </div>
           )}
         </div>

--- a/src/routes/_authenticated/admin.modul.tsx
+++ b/src/routes/_authenticated/admin.modul.tsx
@@ -78,7 +78,10 @@ function ModulPage() {
   }
 
   function exportBank(modul: Modul) {
-    const topik = topikRepo.all().filter((t) => t.modulId === modul.id);
+    let topik = topikRepo.all().filter((t) => t.modulId === modul.id);
+    if (!canEdit && allowedSet) {
+      topik = topik.filter((t) => allowedSet.has(t.id));
+    }
     const tIds = new Set(topik.map((t) => t.id));
     const soal = soalRepo.all().filter((s) => tIds.has(s.topikId));
     const bank: Bank = { app: "cbtman-bank", version: 1, modul, topik, soal };

--- a/src/routes/_authenticated/admin.modul.tsx
+++ b/src/routes/_authenticated/admin.modul.tsx
@@ -207,63 +207,73 @@ function ModulPage() {
         )}
       </div>
 
-      <AdminPageContent>
-        <div className="flex flex-col divide-y divide-slate-100 dark:divide-slate-800">
-          {shown.map((m) => {
-            const tAll = topikRepo.all().filter((t) => t.modulId === m.id);
-            const t = allowedSet ? tAll.filter((x) => allowedSet.has(x.id)) : tAll;
-            const tIds = new Set(t.map((x) => x.id));
-            const sCount = soalRepo.all().filter((s) => tIds.has(s.topikId)).length;
-            const mkName = m.mataKuliahId ? mkList.find((x) => x.id === m.mataKuliahId)?.nama : null;
+            <AdminPageContent className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-100 font-semibold">
+              <tr>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-left border-r border-slate-200 dark:border-slate-800">Nama Modul</th>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-left border-r border-slate-200 dark:border-slate-800">Mata Kuliah</th>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center border-r border-slate-200 dark:border-slate-800">Topik</th>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center border-r border-slate-200 dark:border-slate-800">Soal</th>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center">Aksi</th>
+              </tr>
+            </thead>
+            <tbody>
+              {shown.map((m) => {
+                const tAll = topikRepo.all().filter((t) => t.modulId === m.id);
+                const t = allowedSet ? tAll.filter((x) => allowedSet.has(x.id)) : tAll;
+                const tIds = new Set(t.map((x) => x.id));
+                const sCount = soalRepo.all().filter((s) => tIds.has(s.topikId)).length;
+                const mkName = m.mataKuliahId ? mkList.find((x) => x.id === m.mataKuliahId)?.nama : null;
 
-            return (
-              <div key={m.id} className="group flex flex-col sm:flex-row sm:items-center justify-between p-4 sm:px-6 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors gap-4">
-                
-                <div className="flex items-center gap-4">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400">
-                    <FileText className="h-5 w-5" />
-                  </div>
-                  <div className="flex-1 min-w-0 space-y-1">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <Link to="/admin/modul/$id/topik" params={{ id: m.id }} className="text-sm font-semibold text-slate-900 dark:text-slate-100 hover:text-primary transition-colors truncate">
+                return (
+                  <tr key={m.id} className="transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                    <td className="p-4 font-medium text-slate-900 dark:text-slate-100 border-r border-slate-200 dark:border-slate-800">
+                      <Link to="/admin/modul/$id/topik" params={{ id: m.id }} className="hover:text-primary transition-colors">
                         {m.nama}
                       </Link>
-                      {mkName && (
-                        <span className="px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 text-[10px] font-semibold tracking-wide uppercase text-slate-500">
+                    </td>
+                    <td className="p-4 text-slate-600 dark:text-slate-400 border-r border-slate-200 dark:border-slate-800">
+                      {mkName ? (
+                        <span className="px-2 py-0.5 rounded text-xs font-semibold bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
                           {mkName}
                         </span>
+                      ) : (
+                        <span className="text-slate-400">-</span>
                       )}
-                    </div>
-                    <div className="flex items-center gap-4 text-xs font-medium text-slate-500 mt-1">
-                      <span className="flex items-center gap-1.5"><FileText className="w-3.5 h-3.5 text-slate-400"/> {t.length} Topik</span>
-                      <span className="flex items-center gap-1.5"><ChevronRight className="w-3.5 h-3.5 text-slate-400"/> {sCount} Soal</span>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="flex items-center gap-2 opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
-                  <Button size="sm" variant="outline" className="h-8 shadow-sm bg-white dark:bg-slate-900" onClick={() => exportBank(m)} title="Export JSON">
-                    <Download className="mr-2 h-3.5 w-3.5" /> Export
-                  </Button>
-                  {canEdit && (
-                    <Button size="sm" variant="ghost" className="h-8 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950" onClick={() => remove(m.id)}>
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  )}
-                  <Button size="sm" className="h-8 shadow-sm" asChild>
-                    <Link to="/admin/modul/$id/topik" params={{ id: m.id }}>
-                      Kelola Topik
-                    </Link>
-                  </Button>
-                </div>
-              </div>
-            );
-          })}
-          {shown.length === 0 && (
-            <div className="p-8 text-center text-slate-500 text-sm">
-              Belum ada modul bank soal.
-            </div>
-          )}
+                    </td>
+                    <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
+                      <span className="font-semibold text-slate-700 dark:text-slate-300">{t.length}</span>
+                    </td>
+                    <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
+                      <span className="font-semibold text-slate-700 dark:text-slate-300">{sCount}</span>
+                    </td>
+                    <td className="p-4 text-center space-x-2">
+                      <Button size="sm" variant="outline" className="h-8 shadow-sm" asChild>
+                        <Link to="/admin/modul/$id/topik" params={{ id: m.id }}>
+                          Kelola Topik
+                        </Link>
+                      </Button>
+                      <Button size="sm" variant="outline" className="h-8 shadow-sm bg-white dark:bg-slate-900" onClick={() => exportBank(m)} title="Export JSON">
+                        <Download className="h-4 w-4" />
+                      </Button>
+                      {canEdit && (
+                        <Button size="sm" variant="ghost" className="h-8 text-destructive hover:bg-destructive/10" onClick={() => remove(m.id)}>
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+              {shown.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="p-8 text-center text-slate-500">Belum ada modul bank soal.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
         </div>
       </AdminPageContent>
     </AdminPage>

--- a/src/routes/_authenticated/admin.modul.tsx
+++ b/src/routes/_authenticated/admin.modul.tsx
@@ -207,73 +207,63 @@ function ModulPage() {
         )}
       </div>
 
-            <AdminPageContent className="p-0">
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead className="bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-100 font-semibold">
-              <tr>
-                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-left border-r border-slate-200 dark:border-slate-800">Nama Modul</th>
-                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-left border-r border-slate-200 dark:border-slate-800">Mata Kuliah</th>
-                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center border-r border-slate-200 dark:border-slate-800">Topik</th>
-                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center border-r border-slate-200 dark:border-slate-800">Soal</th>
-                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center">Aksi</th>
-              </tr>
-            </thead>
-            <tbody>
-              {shown.map((m) => {
-                const tAll = topikRepo.all().filter((t) => t.modulId === m.id);
-                const t = allowedSet ? tAll.filter((x) => allowedSet.has(x.id)) : tAll;
-                const tIds = new Set(t.map((x) => x.id));
-                const sCount = soalRepo.all().filter((s) => tIds.has(s.topikId)).length;
-                const mkName = m.mataKuliahId ? mkList.find((x) => x.id === m.mataKuliahId)?.nama : null;
+      <AdminPageContent>
+        <div className="flex flex-col divide-y divide-slate-100 dark:divide-slate-800">
+          {shown.map((m) => {
+            const tAll = topikRepo.all().filter((t) => t.modulId === m.id);
+            const t = allowedSet ? tAll.filter((x) => allowedSet.has(x.id)) : tAll;
+            const tIds = new Set(t.map((x) => x.id));
+            const sCount = soalRepo.all().filter((s) => tIds.has(s.topikId)).length;
+            const mkName = m.mataKuliahId ? mkList.find((x) => x.id === m.mataKuliahId)?.nama : null;
 
-                return (
-                  <tr key={m.id} className="transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50">
-                    <td className="p-4 font-medium text-slate-900 dark:text-slate-100 border-r border-slate-200 dark:border-slate-800">
-                      <Link to="/admin/modul/$id/topik" params={{ id: m.id }} className="hover:text-primary transition-colors">
+            return (
+              <div key={m.id} className="group flex flex-col sm:flex-row sm:items-center justify-between p-4 sm:px-6 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors gap-4">
+                
+                <div className="flex items-center gap-4">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400">
+                    <FileText className="h-5 w-5" />
+                  </div>
+                  <div className="flex-1 min-w-0 space-y-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Link to="/admin/modul/$id/topik" params={{ id: m.id }} className="text-sm font-semibold text-slate-900 dark:text-slate-100 hover:text-primary transition-colors truncate">
                         {m.nama}
                       </Link>
-                    </td>
-                    <td className="p-4 text-slate-600 dark:text-slate-400 border-r border-slate-200 dark:border-slate-800">
-                      {mkName ? (
-                        <span className="px-2 py-0.5 rounded text-xs font-semibold bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
+                      {mkName && (
+                        <span className="px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 text-[10px] font-semibold tracking-wide uppercase text-slate-500">
                           {mkName}
                         </span>
-                      ) : (
-                        <span className="text-slate-400">-</span>
                       )}
-                    </td>
-                    <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
-                      <span className="font-semibold text-slate-700 dark:text-slate-300">{t.length}</span>
-                    </td>
-                    <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
-                      <span className="font-semibold text-slate-700 dark:text-slate-300">{sCount}</span>
-                    </td>
-                    <td className="p-4 text-center space-x-2">
-                      <Button size="sm" variant="outline" className="h-8 shadow-sm" asChild>
-                        <Link to="/admin/modul/$id/topik" params={{ id: m.id }}>
-                          Kelola Topik
-                        </Link>
-                      </Button>
-                      <Button size="sm" variant="outline" className="h-8 shadow-sm bg-white dark:bg-slate-900" onClick={() => exportBank(m)} title="Export JSON">
-                        <Download className="h-4 w-4" />
-                      </Button>
-                      {canEdit && (
-                        <Button size="sm" variant="ghost" className="h-8 text-destructive hover:bg-destructive/10" onClick={() => remove(m.id)}>
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-              {shown.length === 0 && (
-                <tr>
-                  <td colSpan={5} className="p-8 text-center text-slate-500">Belum ada modul bank soal.</td>
-                </tr>
-              )}
-            </tbody>
-          </table>
+                    </div>
+                    <div className="flex items-center gap-4 text-xs font-medium text-slate-500 mt-1">
+                      <span className="flex items-center gap-1.5"><FileText className="w-3.5 h-3.5 text-slate-400"/> {t.length} Topik</span>
+                      <span className="flex items-center gap-1.5"><ChevronRight className="w-3.5 h-3.5 text-slate-400"/> {sCount} Soal</span>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2 opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+                  <Button size="sm" variant="outline" className="h-8 shadow-sm bg-white dark:bg-slate-900" onClick={() => exportBank(m)} title="Export JSON">
+                    <Download className="mr-2 h-3.5 w-3.5" /> Export
+                  </Button>
+                  {canEdit && (
+                    <Button size="sm" variant="ghost" className="h-8 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950" onClick={() => remove(m.id)}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                  <Button size="sm" className="h-8 shadow-sm" asChild>
+                    <Link to="/admin/modul/$id/topik" params={{ id: m.id }}>
+                      Kelola Topik
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+          {shown.length === 0 && (
+            <div className="p-8 text-center text-slate-500 text-sm">
+              Belum ada modul bank soal.
+            </div>
+          )}
         </div>
       </AdminPageContent>
     </AdminPage>

--- a/src/routes/_authenticated/admin.peserta.index.tsx
+++ b/src/routes/_authenticated/admin.peserta.index.tsx
@@ -164,10 +164,10 @@ function PesertaPage() {
                     )}
                   </td>
                   <td className="p-4 text-center space-x-2">
-                    <Button variant="outline" size="sm" onClick={() => { setEditing(p); setOpen(true); }} className="h-8">
+                    <Button variant="outline" size="sm" onClick={() => { setEditing(p); setOpen(true); }} className="h-8" aria-label="Edit">
                       <Pencil className="h-4 w-4" />
                     </Button>
-                    <Button variant="ghost" size="sm" className="h-8 text-destructive hover:bg-destructive/10" onClick={() => {
+                    <Button variant="ghost" size="sm" className="h-8 text-destructive hover:bg-destructive/10" aria-label="Hapus" onClick={() => {
                       if (confirm("Hapus peserta ini?")) {
                         usersRepo.remove(p.id);
                         refresh();

--- a/src/routes/_authenticated/admin.peserta.index.tsx
+++ b/src/routes/_authenticated/admin.peserta.index.tsx
@@ -7,6 +7,7 @@ import { upsertUserServer } from "@/lib/server/users/functions";
 import { uid } from "@/lib/cbt/storage";
 import type { Group, User } from "@/lib/cbt/types";
 import { Card, CardContent } from "@/components/ui/card";
+import { AdminPage, AdminPageHeader, AdminPageContent } from "@/components/cbt/AdminPage";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -83,38 +84,35 @@ function PesertaPage() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl space-y-6">
-      {/* Header Section */}
-      <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
-        <div className="space-y-1">
-          <h1 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">Akun Peserta</h1>
-          <p className="text-sm text-slate-500">
-            Kelola data mahasiswa, grup kelas, dan cetak kartu ujian.
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <input id="file-upload" type="file" accept=".xlsx,.xls" hidden onChange={(e) => {
-            const f = e.target.files?.[0]; if (f) importExcel(f); e.target.value = "";
-          }} />
-          <Button variant="outline" size="sm" onClick={() => document.getElementById("file-upload")?.click()} className="h-9">
-            <Upload className="mr-2 h-4 w-4" /> Import Excel
-          </Button>
-          <div className="w-px h-6 bg-slate-200 dark:bg-slate-700 mx-1"></div>
-          <Link to="/admin/peserta/group">
-            <Button variant="outline" size="sm" className="h-9">
-              <UsersIcon className="mr-2 h-4 w-4" /> Grup Kelas
+        <AdminPage>
+      <AdminPageHeader
+        title="Akun Peserta"
+        description="Kelola data mahasiswa, grup kelas, dan import akun dari Excel."
+        action={
+          <div className="flex flex-wrap items-center gap-2">
+            <input id="file-upload" type="file" accept=".xlsx,.xls" hidden onChange={(e) => {
+              const f = e.target.files?.[0]; if (f) importExcel(f); e.target.value = "";
+            }} />
+            <Button variant="outline" size="sm" onClick={() => document.getElementById("file-upload")?.click()} className="h-9">
+              <Upload className="mr-2 h-4 w-4" /> Import Excel
             </Button>
-          </Link>
-          <Link to="/admin/peserta/kartu">
-            <Button variant="outline" size="sm" className="h-9">
-              <Printer className="mr-2 h-4 w-4" /> Cetak Kartu
+            <div className="w-px h-6 bg-slate-200 dark:bg-slate-700 mx-1"></div>
+            <Link to="/admin/peserta/group">
+              <Button variant="outline" size="sm" className="h-9">
+                <UsersIcon className="mr-2 h-4 w-4" /> Grup Kelas
+              </Button>
+            </Link>
+            <Link to="/admin/peserta/kartu">
+              <Button variant="outline" size="sm" className="h-9">
+                <Printer className="mr-2 h-4 w-4" /> Cetak Kartu
+              </Button>
+            </Link>
+            <Button onClick={() => { setEditing(null); setOpen(true); }} size="sm" className="h-9">
+              <Plus className="mr-2 h-4 w-4" /> Tambah Peserta
             </Button>
-          </Link>
-          <Button onClick={() => { setEditing(null); setOpen(true); }} size="sm" className="h-9">
-            <Plus className="mr-2 h-4 w-4" /> Tambah Peserta
-          </Button>
-        </div>
-      </div>
+          </div>
+        }
+      />
 
       {/* Toolbar */}
       <div className="flex flex-col sm:flex-row gap-3">
@@ -136,73 +134,61 @@ function PesertaPage() {
       </div>
 
       {/* List Section */}
-      <div className="rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 overflow-hidden shadow-sm">
-        
-        <div className="flex flex-col divide-y divide-slate-100 dark:divide-slate-800">
-          {shown.map((p) => (
-            <div key={p.id} className="group flex flex-col sm:flex-row sm:items-center justify-between p-4 sm:px-6 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors gap-4">
-              
-              {/* User Info */}
-              <div className="flex items-center gap-4">
-                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 font-bold uppercase">
-                  {p.namaLengkap.charAt(0)}
-                </div>
-                <div>
-                  <div className="flex items-center gap-2">
-                    <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{p.namaLengkap}</h3>
-                    <span className="px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 text-[10px] font-semibold tracking-wide text-slate-500">
-                      Grup: {groups.find((g) => g.id === p.groupId)?.nama ?? "-"}
+      <AdminPageContent className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-100 font-semibold">
+              <tr>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-left border-r border-slate-200 dark:border-slate-800">Username</th>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-left border-r border-slate-200 dark:border-slate-800">Nama Lengkap</th>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center border-r border-slate-200 dark:border-slate-800">Grup / Kelas</th>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center border-r border-slate-200 dark:border-slate-800">Status</th>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center">Aksi</th>
+              </tr>
+            </thead>
+            <tbody>
+              {shown.map((p) => (
+                <tr key={p.id} className="transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                  <td className="p-4 font-medium text-slate-900 dark:text-slate-100 border-r border-slate-200 dark:border-slate-800 text-left">{p.username}</td>
+                  <td className="p-4 text-slate-600 dark:text-slate-400 border-r border-slate-200 dark:border-slate-800 text-left">{p.namaLengkap}</td>
+                  <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
+                    <span className="px-2 py-0.5 rounded text-xs font-semibold bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
+                      {groups.find((g) => g.id === p.groupId)?.nama ?? "-"}
                     </span>
-                    {!p.aktif && (
-                      <span className="px-2 py-0.5 rounded-full bg-red-100 dark:bg-red-900/30 text-[10px] font-semibold tracking-wide uppercase text-red-600 dark:text-red-400">
-                        Nonaktif
-                      </span>
+                  </td>
+                  <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
+                    {p.aktif ? (
+                      <span className="px-2 py-0.5 rounded text-xs font-semibold bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">Aktif</span>
+                    ) : (
+                      <span className="px-2 py-0.5 rounded text-xs font-semibold bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">Nonaktif</span>
                     )}
-                  </div>
-                  <p className="text-xs font-mono text-slate-500 mt-0.5">{p.username}</p>
-                </div>
-              </div>
-
-              {/* Actions */}
-              <div className="flex items-center gap-1 opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity">
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-8 w-8 p-0 text-slate-400 hover:text-slate-900 dark:hover:text-white"
-                  onClick={() => {
-                    setEditing(p);
-                    setOpen(true);
-                  }}
-                  title="Edit"
-                >
-                  <Pencil className="h-4 w-4" />
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-8 w-8 p-0 text-slate-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
-                  title="Hapus"
-                  onClick={() => {
-                    if (!confirm("Hapus peserta ini?")) return;
-                    usersRepo.remove(p.id);
-                    refresh();
-                  }}
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
-          ))}
-          {shown.length === 0 && (
-            <div className="py-12 text-center text-slate-400 text-sm">
-              Tidak ada data peserta yang sesuai.
-            </div>
-          )}
+                  </td>
+                  <td className="p-4 text-center space-x-2">
+                    <Button variant="outline" size="sm" onClick={() => { setEditing(p); setOpen(true); }} className="h-8">
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button variant="ghost" size="sm" className="h-8 text-destructive hover:bg-destructive/10" onClick={() => {
+                      if (confirm("Hapus peserta ini?")) {
+                        usersRepo.remove(p.id);
+                        refresh();
+                      }
+                    }}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+              {shown.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="p-8 text-center text-slate-500">Tidak ada data peserta yang sesuai.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
         </div>
-      </div>
-
-      <PesertaDialog open={open} onOpenChange={setOpen} editing={editing} groups={groups} onSaved={refresh} />
-    </div>
+      </AdminPageContent>
+<PesertaDialog open={open} onOpenChange={setOpen} editing={editing} groups={groups} onSaved={refresh} />
+    </AdminPage>
   );
 }
 

--- a/src/routes/_authenticated/admin.topik.$id.soal.tsx
+++ b/src/routes/_authenticated/admin.topik.$id.soal.tsx
@@ -123,72 +123,82 @@ function SoalPage() {
         </div>
       </div>
 
-      {/* Sleek List Section */}
-      <section className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-sm overflow-hidden">
-        <div className="px-6 py-4 border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50">
-          <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500">Daftar Soal ({shown.length})</h2>
-        </div>
+      {/* Cards Section */}
+      <div className="space-y-6">
+        {shown.map((s, i) => (
+          <div key={s.id} className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-sm overflow-hidden flex flex-col">
+            {/* Header */}
+            <div className="flex flex-wrap items-center justify-between px-5 py-3 border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50 gap-3">
+              <div className="flex items-center gap-3 flex-wrap">
+                <span className="flex items-center justify-center w-6 h-6 rounded bg-slate-200 dark:bg-slate-700 font-mono text-xs font-bold text-slate-600 dark:text-slate-300">
+                  {i + 1}
+                </span>
+                <span className="rounded-full bg-slate-100 dark:bg-slate-800 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                  {TIPE_LABEL[s.tipe]}
+                </span>
+                <span className={`rounded-full px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
+                  s.kesulitan === 'mudah' ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400' :
+                  s.kesulitan === 'sedang' ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400' :
+                  'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400'
+                }`}>
+                  {KES_LABEL[s.kesulitan]}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button size="sm" variant="ghost" className="h-7 px-2 text-slate-500 hover:text-slate-900 dark:hover:text-slate-100" onClick={() => { setEditing(s); setOpen(true); }}>
+                  <Pencil className="h-3.5 w-3.5 sm:mr-1.5" /> <span className="hidden sm:inline">Edit</span>
+                </Button>
+                <div className="w-px h-4 bg-slate-200 dark:bg-slate-700"></div>
+                <Button size="sm" variant="ghost" className="h-7 px-2 text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950" onClick={() => remove(s.id)}>
+                  <Trash2 className="h-3.5 w-3.5 sm:mr-1.5" /> <span className="hidden sm:inline">Hapus</span>
+                </Button>
+              </div>
+            </div>
+            
+            {/* Content */}
+            <div className="p-5 space-y-5">
+              <div className="text-sm prose prose-sm dark:prose-invert max-w-none prose-p:leading-relaxed">
+                <RichView html={s.detail} />
+              </div>
+              
+              {s.tipe !== "essay" && (
+                <div className="grid gap-2">
+                  {s.jawaban.map((j, idx) => (
+                    <div key={j.id} className={`flex items-start gap-3 p-3 rounded-lg border transition-colors ${
+                      j.benar 
+                        ? 'bg-emerald-50/50 border-emerald-500 dark:bg-emerald-950/20 dark:border-emerald-500/50' 
+                        : 'bg-white border-slate-200 dark:bg-slate-900 dark:border-slate-800'
+                    }`}>
+                      <span className={`flex shrink-0 items-center justify-center w-6 h-6 rounded-md font-mono text-sm font-semibold ${
+                        j.benar 
+                          ? 'bg-emerald-500 text-white dark:bg-emerald-600' 
+                          : 'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400'
+                      }`}>
+                        {String.fromCharCode(65 + idx)}
+                      </span>
+                      <div className={`flex-1 text-sm pt-0.5 ${j.benar ? 'text-emerald-900 dark:text-emerald-100' : 'text-slate-700 dark:text-slate-300'}`}>
+                        <RichView html={j.detail} className="inline" />
+                      </div>
+                      {j.benar && (
+                        <div className="flex shrink-0 items-center justify-center h-6">
+                          <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
         
-        <div className="flex flex-col divide-y divide-slate-100 dark:divide-slate-800">
-          {shown.map((s, i) => (
-            <div key={s.id} className="group flex flex-col md:flex-row items-start justify-between p-5 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors gap-6">
-              
-              <div className="flex-1 w-full space-y-3">
-                <div className="flex items-center gap-2">
-                  <span className="font-mono text-xs font-semibold text-slate-400">#{i + 1}</span>
-                  <span className="rounded-full bg-slate-100 dark:bg-slate-800 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-slate-500">
-                    {TIPE_LABEL[s.tipe]}
-                  </span>
-                  <span className={`rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
-                    s.kesulitan === 'mudah' ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400' :
-                    s.kesulitan === 'sedang' ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400' :
-                    'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400'
-                  }`}>
-                    {KES_LABEL[s.kesulitan]}
-                  </span>
-                </div>
-                
-                <div className="text-sm prose prose-sm dark:prose-invert max-w-none prose-p:leading-relaxed">
-                  <RichView html={s.detail} />
-                </div>
-                
-                {s.tipe !== "essay" && (
-                  <div className="mt-4 pt-3 border-t border-slate-100 dark:border-slate-800/60">
-                    <ul className="space-y-2 text-sm">
-                      {s.jawaban.map((j, idx) => (
-                        <li key={j.id} className={`flex items-start gap-2 ${j.benar ? 'text-emerald-700 dark:text-emerald-400 font-medium' : 'text-slate-600 dark:text-slate-400'}`}>
-                          <span className="font-mono mt-0.5 min-w-[20px]">{String.fromCharCode(65 + idx)}.</span>
-                          <span className="flex-1">
-                            <RichView html={j.detail} className="inline" />
-                          </span>
-                          {j.benar && <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5 text-emerald-500" />}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-              </div>
-              
-              <div className="flex md:flex-col items-center gap-2 md:opacity-0 group-hover:opacity-100 transition-opacity shrink-0 w-full md:w-auto justify-end">
-                <Button size="sm" variant="outline" className="h-8 w-full md:w-auto bg-white dark:bg-slate-900 shadow-sm" onClick={() => { setEditing(s); setOpen(true); }}>
-                  <Pencil className="mr-2 h-3.5 w-3.5" /> Edit
-                </Button>
-                <Button size="sm" variant="ghost" className="h-8 w-full md:w-auto text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950" onClick={() => remove(s.id)}>
-                  <Trash2 className="mr-2 h-3.5 w-3.5" /> Hapus
-                </Button>
-              </div>
-
-            </div>
-          ))}
-          
-          {shown.length === 0 && (
-            <div className="py-16 text-center">
-              <BookOpen className="h-10 w-10 text-slate-300 mx-auto mb-3" />
-              <p className="text-slate-500">Tidak ada soal yang ditemukan.</p>
-            </div>
-          )}
-        </div>
-      </section>
+        {shown.length === 0 && (
+          <div className="py-20 text-center bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800">
+            <BookOpen className="h-12 w-12 text-slate-300 mx-auto mb-4" />
+            <p className="text-slate-500 font-medium">Belum ada soal untuk topik ini.</p>
+          </div>
+        )}
+      </div>
 
       <SoalDialog open={open} onOpenChange={setOpen} editing={editing} topikId={topikId} onSaved={refresh} />
     </div>

--- a/src/routes/_authenticated/admin.topik.$id.soal.tsx
+++ b/src/routes/_authenticated/admin.topik.$id.soal.tsx
@@ -64,43 +64,52 @@ function SoalPage() {
   );
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 animate-in fade-in duration-500 pb-12 pt-4">
-      {/* Header Section */}
-      <div className="flex flex-col gap-4 md:flex-row md:items-end justify-between border-b border-slate-200 dark:border-white/10 pb-6">
-        <div className="space-y-2">
-          <div className="flex items-center text-sm font-medium text-muted-foreground gap-2">
-            <Link to="/admin/modul" className="hover:text-primary transition-colors flex items-center gap-1">
-              ← Modul
-            </Link>
-            <span>/</span>
-            <Link to="/admin/modul/$id/topik" params={{ id: modul.id }} className="hover:text-primary transition-colors">
-              {modul.nama}
-            </Link>
-          </div>
-          <div className="flex items-center gap-2">
-            <ListChecks className="h-6 w-6 text-slate-400" />
-            <h1 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-white">{topik.nama}</h1>
-            <span className="px-2.5 py-0.5 rounded-full bg-primary/10 text-primary text-xs font-bold ml-2">
-              {soals.length} Soal
-            </span>
+    <div className="relative min-h-screen">
+      {/* Subtle radial glow background */}
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,_var(--tw-gradient-stops))] from-indigo-50/50 via-white to-white dark:from-indigo-950/20 dark:via-zinc-950 dark:to-zinc-950 -z-10" />
+      
+      <div className="mx-auto max-w-6xl space-y-12 animate-in fade-in duration-700 pb-32 pt-16 px-4 sm:px-6 lg:px-8">
+        {/* Studio-Tier Header Section */}
+        <div className="flex flex-col gap-8 md:flex-row md:items-end justify-between">
+          <div className="space-y-5">
+            <div className="flex items-center text-sm font-medium text-slate-500 dark:text-zinc-400 gap-3">
+              <Link to="/admin/modul" className="hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors flex items-center gap-1.5">
+                ← Bank Soal
+              </Link>
+              <span className="text-slate-300 dark:text-zinc-700">/</span>
+              <Link to="/admin/modul/$id/topik" params={{ id: modul.id }} className="hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+                {modul.nama}
+              </Link>
+            </div>
+            
+            <div className="flex flex-col gap-3">
+              <h1 className="text-5xl md:text-6xl font-black tracking-tighter text-slate-900 dark:text-zinc-50 leading-none">
+                {topik.nama}
+              </h1>
+              <div className="flex items-center gap-3 mt-1">
+                <span className="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full bg-indigo-50 dark:bg-indigo-500/10 text-indigo-700 dark:text-indigo-400 text-sm font-bold border border-indigo-100 dark:border-indigo-500/20">
+                  <ListChecks className="h-4 w-4" />
+                  {soals.length} Soal Tersedia
+                </span>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* Toolbar / Filters */}
-      <div className="bg-slate-50 dark:bg-slate-900/50 p-4 rounded-xl border border-slate-200 dark:border-slate-800 flex flex-col md:flex-row gap-3">
+      {/* Premium Toolbar / Filters */}
+      <div className="p-2.5 bg-white/60 dark:bg-zinc-900/40 backdrop-blur-xl rounded-2xl border border-slate-200/80 dark:border-zinc-800/60 shadow-sm flex flex-col md:flex-row gap-2">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+          <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400 dark:text-zinc-500" />
           <Input 
-            className="pl-9 bg-white dark:bg-slate-950 border-slate-200 dark:border-slate-800" 
+            className="pl-11 h-12 bg-white dark:bg-zinc-950 border-transparent hover:border-slate-200 dark:hover:border-zinc-800 focus:border-indigo-500 rounded-xl transition-all shadow-none text-base" 
             placeholder="Cari kata kunci dalam soal…" 
             value={query} 
             onChange={(e) => setQuery(e.target.value)} 
           />
         </div>
-        <div className="flex flex-col sm:flex-row gap-3">
+        <div className="flex flex-col sm:flex-row gap-2">
           <Select value={tipe} onValueChange={setTipe}>
-            <SelectTrigger className="w-full sm:w-44 bg-white dark:bg-slate-950 border-slate-200 dark:border-slate-800">
+            <SelectTrigger className="w-full sm:w-44 h-12 rounded-xl bg-white dark:bg-zinc-950 border-transparent hover:border-slate-200 dark:hover:border-zinc-800 shadow-none font-medium">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -109,7 +118,7 @@ function SoalPage() {
             </SelectContent>
           </Select>
           <Select value={kes} onValueChange={setKes}>
-            <SelectTrigger className="w-full sm:w-40 bg-white dark:bg-slate-950 border-slate-200 dark:border-slate-800">
+            <SelectTrigger className="w-full sm:w-40 h-12 rounded-xl bg-white dark:bg-zinc-950 border-transparent hover:border-slate-200 dark:hover:border-zinc-800 shadow-none font-medium">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -117,70 +126,70 @@ function SoalPage() {
               {Object.entries(KES_LABEL).map(([v, l]) => <SelectItem key={v} value={v}>{l}</SelectItem>)}
             </SelectContent>
           </Select>
-          <Button onClick={() => { setEditing(null); setOpen(true); }} className="w-full sm:w-auto font-semibold">
+          <Button onClick={() => { setEditing(null); setOpen(true); }} className="w-full sm:w-auto h-12 rounded-xl px-6 font-bold bg-slate-900 hover:bg-slate-800 dark:bg-indigo-600 dark:hover:bg-indigo-500 text-white shadow-md shadow-slate-900/10 dark:shadow-indigo-900/20 transition-all">
             <Plus className="mr-2 h-4 w-4" />Soal Baru
           </Button>
         </div>
       </div>
 
-      {/* Cards Section */}
-      <div className="space-y-6">
+      {/* Studio-Tier Cards Section */}
+      <div className="space-y-8">
         {shown.map((s, i) => (
-          <div key={s.id} className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-sm overflow-hidden flex flex-col">
+          <div key={s.id} className="bg-white/80 dark:bg-zinc-900/60 backdrop-blur-sm rounded-2xl border border-slate-200/80 dark:border-zinc-800/80 shadow-sm hover:shadow-md hover:border-slate-300 dark:hover:border-zinc-700 transition-all overflow-hidden flex flex-col">
             {/* Header */}
-            <div className="flex flex-wrap items-center justify-between px-5 py-3 border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50 gap-3">
-              <div className="flex items-center gap-3 flex-wrap">
-                <span className="flex items-center justify-center w-6 h-6 rounded bg-slate-200 dark:bg-slate-700 font-mono text-xs font-bold text-slate-600 dark:text-slate-300">
+            <div className="flex flex-wrap items-center justify-between px-6 py-4 border-b border-slate-100 dark:border-zinc-800/80 bg-slate-50/40 dark:bg-zinc-950/40 gap-3">
+              <div className="flex items-center gap-4 flex-wrap">
+                <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-slate-900 dark:bg-zinc-100 font-mono text-xs font-black text-white dark:text-zinc-900 shadow-sm">
                   {i + 1}
                 </span>
-                <span className="rounded-full bg-slate-100 dark:bg-slate-800 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                <span className="rounded-full bg-slate-200/60 dark:bg-zinc-800 px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-slate-600 dark:text-zinc-400">
                   {TIPE_LABEL[s.tipe]}
                 </span>
-                <span className={`rounded-full px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
-                  s.kesulitan === 'mudah' ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400' :
-                  s.kesulitan === 'sedang' ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400' :
-                  'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400'
+                <span className={`rounded-full px-3 py-1 text-[10px] font-bold uppercase tracking-widest ${
+                  s.kesulitan === 'mudah' ? 'bg-emerald-100 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-400' :
+                  s.kesulitan === 'sedang' ? 'bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-400' :
+                  'bg-rose-100 dark:bg-rose-950/40 text-rose-700 dark:text-rose-400'
                 }`}>
                   {KES_LABEL[s.kesulitan]}
                 </span>
               </div>
-              <div className="flex items-center gap-2">
-                <Button size="sm" variant="ghost" className="h-7 px-2 text-slate-500 hover:text-slate-900 dark:hover:text-slate-100" onClick={() => { setEditing(s); setOpen(true); }}>
-                  <Pencil className="h-3.5 w-3.5 sm:mr-1.5" /> <span className="hidden sm:inline">Edit</span>
+              <div className="flex items-center gap-1.5">
+                <Button size="sm" variant="ghost" className="h-8 px-3 rounded-lg text-slate-500 hover:text-slate-900 hover:bg-slate-100 dark:hover:text-zinc-100 dark:hover:bg-zinc-800 font-medium" onClick={() => { setEditing(s); setOpen(true); }}>
+                  <Pencil className="h-3.5 w-3.5 sm:mr-2" /> <span className="hidden sm:inline">Edit</span>
                 </Button>
-                <div className="w-px h-4 bg-slate-200 dark:bg-slate-700"></div>
-                <Button size="sm" variant="ghost" className="h-7 px-2 text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950" onClick={() => remove(s.id)}>
-                  <Trash2 className="h-3.5 w-3.5 sm:mr-1.5" /> <span className="hidden sm:inline">Hapus</span>
+                <div className="w-px h-5 bg-slate-200 dark:bg-zinc-700 mx-1"></div>
+                <Button size="sm" variant="ghost" className="h-8 px-3 rounded-lg text-rose-500 hover:text-rose-700 hover:bg-rose-50 dark:hover:bg-rose-950/50 font-medium" onClick={() => remove(s.id)}>
+                  <Trash2 className="h-3.5 w-3.5 sm:mr-2" /> <span className="hidden sm:inline">Hapus</span>
                 </Button>
               </div>
             </div>
             
             {/* Content */}
-            <div className="p-5 space-y-5">
-              <div className="text-sm prose prose-sm dark:prose-invert max-w-none prose-p:leading-relaxed">
+            <div className="p-6 sm:p-8 space-y-6">
+              <div className="text-base prose prose-slate dark:prose-invert max-w-none prose-p:leading-relaxed prose-headings:tracking-tight">
                 <RichView html={s.detail} />
               </div>
               
               {s.tipe !== "essay" && (
-                <div className="grid gap-2">
+                <div className="grid gap-3 mt-4">
                   {s.jawaban.map((j, idx) => (
-                    <div key={j.id} className={`flex items-start gap-3 p-3 rounded-lg border transition-colors ${
+                    <div key={j.id} className={`flex items-start gap-4 p-4 rounded-xl border transition-all ${
                       j.benar 
-                        ? 'bg-emerald-50/50 border-emerald-500 dark:bg-emerald-950/20 dark:border-emerald-500/50' 
-                        : 'bg-white border-slate-200 dark:bg-slate-900 dark:border-slate-800'
+                        ? 'bg-emerald-50/80 border-emerald-500/50 dark:bg-emerald-500/10 dark:border-emerald-500/30 shadow-sm shadow-emerald-100/50 dark:shadow-none' 
+                        : 'bg-white border-slate-200/80 hover:border-slate-300 dark:bg-zinc-900/50 dark:border-zinc-800 dark:hover:border-zinc-700'
                     }`}>
-                      <span className={`flex shrink-0 items-center justify-center w-6 h-6 rounded-md font-mono text-sm font-semibold ${
+                      <span className={`flex shrink-0 items-center justify-center w-7 h-7 rounded-md font-mono text-sm font-bold shadow-sm ${
                         j.benar 
                           ? 'bg-emerald-500 text-white dark:bg-emerald-600' 
-                          : 'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400'
+                          : 'bg-slate-100 text-slate-500 dark:bg-zinc-800 dark:text-zinc-400'
                       }`}>
                         {String.fromCharCode(65 + idx)}
                       </span>
-                      <div className={`flex-1 text-sm pt-0.5 ${j.benar ? 'text-emerald-900 dark:text-emerald-100' : 'text-slate-700 dark:text-slate-300'}`}>
+                      <div className={`flex-1 text-sm pt-1 font-medium ${j.benar ? 'text-emerald-950 dark:text-emerald-100' : 'text-slate-700 dark:text-zinc-300'}`}>
                         <RichView html={j.detail} className="inline" />
                       </div>
                       {j.benar && (
-                        <div className="flex shrink-0 items-center justify-center h-6">
+                        <div className="flex shrink-0 items-center justify-center h-7">
                           <CheckCircle2 className="h-5 w-5 text-emerald-500" />
                         </div>
                       )}
@@ -193,14 +202,18 @@ function SoalPage() {
         ))}
         
         {shown.length === 0 && (
-          <div className="py-20 text-center bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800">
-            <BookOpen className="h-12 w-12 text-slate-300 mx-auto mb-4" />
-            <p className="text-slate-500 font-medium">Belum ada soal untuk topik ini.</p>
+          <div className="py-24 text-center bg-white/50 dark:bg-zinc-900/30 backdrop-blur-sm rounded-2xl border border-dashed border-slate-300 dark:border-zinc-800">
+            <div className="inline-flex h-16 w-16 items-center justify-center rounded-full bg-slate-100 dark:bg-zinc-800 mb-4">
+              <BookOpen className="h-8 w-8 text-slate-400 dark:text-zinc-500" />
+            </div>
+            <h3 className="text-lg font-bold tracking-tight text-slate-900 dark:text-zinc-100">Belum ada soal</h3>
+            <p className="text-slate-500 dark:text-zinc-400 mt-1">Gunakan tombol "Soal Baru" untuk mulai menambahkan soal.</p>
           </div>
         )}
       </div>
 
       <SoalDialog open={open} onOpenChange={setOpen} editing={editing} topikId={topikId} onSaved={refresh} />
+      </div>
     </div>
   );
 }

--- a/src/routes/_authenticated/admin.topik.$id.soal.tsx
+++ b/src/routes/_authenticated/admin.topik.$id.soal.tsx
@@ -154,11 +154,11 @@ function SoalPage() {
                 </span>
               </div>
               <div className="flex items-center gap-1.5">
-                <Button size="sm" variant="ghost" className="h-8 px-3 rounded-lg text-slate-500 hover:text-slate-900 hover:bg-slate-100 dark:hover:text-zinc-100 dark:hover:bg-zinc-800 font-medium" onClick={() => { setEditing(s); setOpen(true); }}>
+                <Button size="sm" variant="ghost" className="h-8 px-3 rounded-lg text-slate-500 hover:text-slate-900 hover:bg-slate-100 dark:hover:text-zinc-100 dark:hover:bg-zinc-800 font-medium" aria-label="Edit" onClick={() => { setEditing(s); setOpen(true); }}>
                   <Pencil className="h-3.5 w-3.5 sm:mr-2" /> <span className="hidden sm:inline">Edit</span>
                 </Button>
                 <div className="w-px h-5 bg-slate-200 dark:bg-zinc-700 mx-1"></div>
-                <Button size="sm" variant="ghost" className="h-8 px-3 rounded-lg text-rose-500 hover:text-rose-700 hover:bg-rose-50 dark:hover:bg-rose-950/50 font-medium" onClick={() => remove(s.id)}>
+                <Button size="sm" variant="ghost" className="h-8 px-3 rounded-lg text-rose-500 hover:text-rose-700 hover:bg-rose-50 dark:hover:bg-rose-950/50 font-medium" aria-label="Hapus" onClick={() => remove(s.id)}>
                   <Trash2 className="h-3.5 w-3.5 sm:mr-2" /> <span className="hidden sm:inline">Hapus</span>
                 </Button>
               </div>

--- a/src/routes/_authenticated/admin.users.tsx
+++ b/src/routes/_authenticated/admin.users.tsx
@@ -80,85 +80,69 @@ function UsersPage() {
       </div>
 
       {/* List Section */}
-      <AdminPageContent>
-        <div className="flex flex-col divide-y divide-slate-100 dark:divide-slate-800">
-          {shown.map((u) => (
-            <div key={u.id} className="group flex flex-col sm:flex-row sm:items-center justify-between p-4 sm:px-6 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors gap-4">
-              
-              {/* User Info */}
-              <div className="flex items-center gap-4">
-                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 font-bold uppercase shrink-0">
-                  {u.namaLengkap.charAt(0)}
-                </div>
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">{u.namaLengkap}</h3>
-                    <span className="px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 text-[10px] font-semibold tracking-wide uppercase text-slate-500">
+            <AdminPageContent className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-100 font-semibold">
+              <tr>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-left border-r border-slate-200 dark:border-slate-800">Username</th>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-left border-r border-slate-200 dark:border-slate-800">Nama Lengkap</th>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center border-r border-slate-200 dark:border-slate-800">Peran</th>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center border-r border-slate-200 dark:border-slate-800">Status</th>
+                <th className="p-4 font-semibold text-slate-700 dark:text-slate-300 text-center">Aksi</th>
+              </tr>
+            </thead>
+            <tbody>
+              {shown.map((u) => (
+                <tr key={u.id} className="transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                  <td className="p-4 font-medium text-slate-900 dark:text-slate-100 border-r border-slate-200 dark:border-slate-800 text-left">{u.username}</td>
+                  <td className="p-4 text-slate-600 dark:text-slate-400 border-r border-slate-200 dark:border-slate-800 text-left">{u.namaLengkap}</td>
+                  <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
+                    <span className="px-2 py-0.5 rounded text-xs font-semibold bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
                       {u.role === "super_admin" ? "Super Admin" : u.role === "admin_prodi" ? "Admin Prodi" : u.role === "evaluator" ? "Evaluator" : u.role}
                     </span>
-                    {!u.aktif && (
-                      <span className="px-2 py-0.5 rounded-full bg-red-100 dark:bg-red-900/30 text-[10px] font-semibold tracking-wide uppercase text-red-600 dark:text-red-400">
-                        Nonaktif
-                      </span>
+                  </td>
+                  <td className="p-4 text-center border-r border-slate-200 dark:border-slate-800">
+                    {u.aktif ? (
+                      <span className="px-2 py-0.5 rounded text-xs font-semibold bg-success/15 text-success">Aktif</span>
+                    ) : (
+                      <span className="px-2 py-0.5 rounded text-xs font-semibold bg-destructive/15 text-destructive">Nonaktif</span>
                     )}
-                  </div>
-                  <p className="text-xs font-mono text-slate-500 mt-0.5 truncate">{u.username}</p>
-                </div>
-              </div>
-
-              {/* Actions */}
-              <div className="flex items-center gap-1 opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-8 w-8 p-0 text-slate-400 hover:text-slate-900 dark:hover:text-white"
-                  onClick={() => {
-                    setEditing(u);
-                    setOpen(true);
-                  }}
-                  title="Edit"
-                >
-                  <Pencil className="h-4 w-4" />
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-8 w-8 p-0 text-slate-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
-                  title="Hapus"
-                  onClick={() => {
-                    if (!confirm("Hapus pengguna ini?")) return;
-                    usersRepo.remove(u.id);
-                    refresh();
-                  }}
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-8 w-8 p-0 text-slate-400 hover:text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-950"
-                  title="Hentikan semua sesi aktif"
-                  onClick={async () => {
-                    if (!confirm("Hentikan semua sesi aktif pengguna ini? (Force logout)")) return;
-                    try {
-                      const res = await revokeUserSessionsServer({ data: { userId: u.id } });
-                      if (res.ok) toast.success("Sesi berhasil dihentikan. Pengguna akan ter-logout.");
-                      else toast.error(res.error ?? "Gagal menghentikan sesi");
-                    } catch {
-                      toast.error("Gagal menghentikan sesi");
-                    }
-                  }}
-                >
-                  <LogOut className="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
-          ))}
-          {shown.length === 0 && (
-            <div className="p-8 text-center text-sm text-slate-500 dark:text-slate-400">
-              Tidak ada data pengguna yang sesuai.
-            </div>
-          )}
+                  </td>
+                  <td className="p-4 text-center space-x-2">
+                    <Button variant="outline" size="sm" onClick={() => { setEditing(u); setOpen(true); }} className="h-8">
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button variant="ghost" size="sm" className="h-8 text-destructive hover:bg-destructive/10" onClick={() => {
+                      if (confirm("Hapus pengguna ini?")) {
+                        usersRepo.remove(u.id);
+                        refresh();
+                      }
+                    }}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                    <Button variant="ghost" size="sm" className="h-8 text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-950" onClick={async () => {
+                      if (!confirm("Hentikan semua sesi aktif pengguna ini? (Force logout)")) return;
+                      try {
+                        const res = await revokeUserSessionsServer({ data: { userId: u.id } });
+                        if (res.ok) toast.success("Sesi berhasil dihentikan. Pengguna akan ter-logout.");
+                        else toast.error(res.error ?? "Gagal menghentikan sesi");
+                      } catch {
+                        toast.error("Gagal menghentikan sesi");
+                      }
+                    }}>
+                      <LogOut className="h-4 w-4" />
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+              {shown.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="p-8 text-center text-slate-500">Tidak ada data pengguna.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
         </div>
       </AdminPageContent>
 

--- a/src/routes/_authenticated/admin.users.tsx
+++ b/src/routes/_authenticated/admin.users.tsx
@@ -110,10 +110,10 @@ function UsersPage() {
                     )}
                   </td>
                   <td className="p-4 text-center space-x-2">
-                    <Button variant="outline" size="sm" onClick={() => { setEditing(u); setOpen(true); }} className="h-8">
+                    <Button variant="outline" size="sm" onClick={() => { setEditing(u); setOpen(true); }} className="h-8" aria-label="Edit">
                       <Pencil className="h-4 w-4" />
                     </Button>
-                    <Button variant="ghost" size="sm" className="h-8 text-destructive hover:bg-destructive/10" onClick={() => {
+                    <Button variant="ghost" size="sm" className="h-8 text-destructive hover:bg-destructive/10" aria-label="Hapus" onClick={() => {
                       if (confirm("Hapus pengguna ini?")) {
                         usersRepo.remove(u.id);
                         refresh();
@@ -121,7 +121,7 @@ function UsersPage() {
                     }}>
                       <Trash2 className="h-4 w-4" />
                     </Button>
-                    <Button variant="ghost" size="sm" className="h-8 text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-950" onClick={async () => {
+                    <Button variant="ghost" size="sm" className="h-8 text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-950" aria-label="Hentikan sesi" onClick={async () => {
                       if (!confirm("Hentikan semua sesi aktif pengguna ini? (Force logout)")) return;
                       try {
                         const res = await revokeUserSessionsServer({ data: { userId: u.id } });


### PR DESCRIPTION
This is Part 2 of the staggered PR submission. It refactors the admin layout tables (Akademik, Users, Peserta, Modul, Soal) into clean, scalable layouts with anti-slop design taste guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Refreshed the Akademik administration page with a modern layout, clearer navigation, and improved informational messaging.
  * Redesigned module management cards with responsive layouts and convenient export/delete actions.
  * Updated question management with richer cards, filters, answer highlighting, and a prominent “Soal Baru” action.
  * Improved participant session tables with clearer alignment and score presentation.
  * Reworked participant and administrator user listings into responsive tables with clearer status and action columns.
  * Added empty states and updated spacing, styling, and responsive behavior across administration pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->