### PR TITLE
refactor(admin): Route-Level Fetching untuk Akademik (PR 3)

### DIFF
--- a/src/lib/server/akademik/functions.ts
+++ b/src/lib/server/akademik/functions.ts
@@ -30,6 +30,42 @@ async function requireSuperAdmin() {
 	return caller;
 }
 
+export const getFakultasList = createServerFn({ method: "GET" }).handler(async () => {
+	const caller = await requireSuperAdmin();
+	if (!caller) throw new Error("Forbidden");
+	return await prisma.fakultas.findMany({ orderBy: { nama: "asc" } });
+});
+
+export const getJurusanList = createServerFn({ method: "GET" }).handler(async () => {
+	const caller = await requireSuperAdmin();
+	if (!caller) throw new Error("Forbidden");
+	return await prisma.jurusan.findMany({ orderBy: { nama: "asc" } });
+});
+
+export const getProdiList = createServerFn({ method: "GET" }).handler(async () => {
+	const caller = await requireSuperAdmin();
+	if (!caller) throw new Error("Forbidden");
+	return await prisma.programStudi.findMany({ orderBy: { nama: "asc" } });
+});
+
+export const getTahunAkademikList = createServerFn({ method: "GET" }).handler(async () => {
+	const caller = await requireSuperAdmin();
+	if (!caller) throw new Error("Forbidden");
+	return await prisma.tahunAkademik.findMany({ orderBy: { nama: "asc" } });
+});
+
+export const getSemesterList = createServerFn({ method: "GET" }).handler(async () => {
+	const caller = await requireSuperAdmin();
+	if (!caller) throw new Error("Forbidden");
+	return await prisma.semester.findMany({ orderBy: { nama: "asc" } });
+});
+
+export const getMataKuliahList = createServerFn({ method: "GET" }).handler(async () => {
+	const caller = await requireSuperAdmin();
+	if (!caller) throw new Error("Forbidden");
+	return await prisma.mataKuliah.findMany({ orderBy: { nama: "asc" } });
+});
+
 export const mutateFakultasServer = createServerFn({ method: "POST" })
 	.validator(z.object({ action: z.enum(["upsert", "remove"]), payload: z.any() }))
 	.handler(async ({ data }) => {

--- a/src/routes/_authenticated/admin.akademik.fakultas.tsx
+++ b/src/routes/_authenticated/admin.akademik.fakultas.tsx
@@ -1,7 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
-import { fakultasRepo } from "@/lib/cbt/repos";
-import { mutateFakultasServer } from "@/lib/server/akademik/functions";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { useState, useEffect } from "react";
+import { mutateFakultasServer, getFakultasList } from "@/lib/server/akademik/functions";
 import { uid } from "@/lib/cbt/storage";
 import type { Fakultas } from "@/lib/cbt/types";
 import { Card, CardContent } from "@/components/ui/card";
@@ -19,11 +18,21 @@ import {
 import { Label } from "@/components/ui/label";
 
 export const Route = createFileRoute("/_authenticated/admin/akademik/fakultas")({
+  loader: async () => {
+    return await getFakultasList();
+  },
   component: FakultasPage,
 });
 
 function FakultasPage() {
-  const [items, setItems] = useState<Fakultas[]>(fakultasRepo.all());
+  const router = useRouter();
+  const initialItems = Route.useLoaderData();
+  const [items, setItems] = useState<Fakultas[]>(initialItems);
+  
+  useEffect(() => {
+    setItems(initialItems);
+  }, [initialItems]);
+
   const [editing, setEditing] = useState<Fakultas | null>(null);
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState({ id: "", nama: "" });
@@ -42,14 +51,18 @@ function FakultasPage() {
 
   async function handleRemove(id: string) {
     if (!confirm("Hapus fakultas ini?")) return;
+    
+    // Optimistic UI
+    setItems((prev) => prev.filter((i) => i.id !== id));
+    
     const res = await mutateFakultasServer({ data: { action: "remove", payload: { id } } });
     if (!res.ok) {
       toast.error(res.error || "Gagal menghapus");
+      await router.invalidate(); // Rollback
       return;
     }
-    fakultasRepo.remove(id);
-    setItems(fakultasRepo.all());
     toast.success("Fakultas dihapus");
+    await router.invalidate();
   }
 
   async function save() {
@@ -58,15 +71,27 @@ function FakultasPage() {
       return;
     }
     const payload: Fakultas = { id: form.id, nama: form.nama.trim() };
+    
+    // Optimistic UI
+    setItems((prev) => {
+      const idx = prev.findIndex((i) => i.id === payload.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = payload;
+        return next;
+      }
+      return [...prev, payload];
+    });
+    setOpen(false);
+
     const res = await mutateFakultasServer({ data: { action: "upsert", payload } });
     if (!res.ok) {
       toast.error(res.error || "Gagal menyimpan");
+      await router.invalidate(); // Rollback
       return;
     }
-    fakultasRepo.upsert(payload);
-    setItems(fakultasRepo.all());
     toast.success("Fakultas disimpan");
-    setOpen(false);
+    await router.invalidate();
   }
 
   return (
@@ -132,3 +157,4 @@ function FakultasPage() {
     </div>
   );
 }
+

--- a/src/routes/_authenticated/admin.akademik.jurusan.tsx
+++ b/src/routes/_authenticated/admin.akademik.jurusan.tsx
@@ -1,7 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
-import { jurusanRepo, fakultasRepo } from "@/lib/cbt/repos";
-import { mutateJurusanServer } from "@/lib/server/akademik/functions";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { useState, useEffect } from "react";
+import { mutateJurusanServer, getJurusanList, getFakultasList } from "@/lib/server/akademik/functions";
 import { uid } from "@/lib/cbt/storage";
 import type { Jurusan } from "@/lib/cbt/types";
 import { Card, CardContent } from "@/components/ui/card";
@@ -26,12 +25,24 @@ import {
 } from "@/components/ui/select";
 
 export const Route = createFileRoute("/_authenticated/admin/akademik/jurusan")({
+  loader: async () => {
+    const [items, fakultasList] = await Promise.all([
+      getJurusanList(),
+      getFakultasList()
+    ]);
+    return { items, fakultasList };
+  },
   component: JurusanPage,
 });
 
 function JurusanPage() {
-  const [items, setItems] = useState<Jurusan[]>(jurusanRepo.all());
-  const fakultasList = fakultasRepo.all();
+  const router = useRouter();
+  const { items: initialItems, fakultasList } = Route.useLoaderData();
+  const [items, setItems] = useState<Jurusan[]>(initialItems);
+  
+  useEffect(() => {
+    setItems(initialItems);
+  }, [initialItems]);
   
   const [editing, setEditing] = useState<Jurusan | null>(null);
   const [open, setOpen] = useState(false);
@@ -51,14 +62,18 @@ function JurusanPage() {
 
   async function handleRemove(id: string) {
     if (!confirm("Hapus jurusan ini?")) return;
+    
+    // Optimistic UI
+    setItems((prev) => prev.filter((i) => i.id !== id));
+    
     const res = await mutateJurusanServer({ data: { action: "remove", payload: { id } } });
     if (!res.ok) {
       toast.error(res.error || "Gagal menghapus");
+      await router.invalidate();
       return;
     }
-    jurusanRepo.remove(id);
-    setItems(jurusanRepo.all());
     toast.success("Jurusan dihapus");
+    await router.invalidate();
   }
 
   async function save() {
@@ -67,15 +82,27 @@ function JurusanPage() {
       return;
     }
     const payload: Jurusan = { id: form.id, nama: form.nama.trim(), fakultasId: form.fakultasId };
+    
+    // Optimistic UI
+    setItems((prev) => {
+      const idx = prev.findIndex((i) => i.id === payload.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = payload;
+        return next;
+      }
+      return [...prev, payload];
+    });
+    setOpen(false);
+
     const res = await mutateJurusanServer({ data: { action: "upsert", payload } });
     if (!res.ok) {
       toast.error(res.error || "Gagal menyimpan");
+      await router.invalidate();
       return;
     }
-    jurusanRepo.upsert(payload);
-    setItems(jurusanRepo.all());
     toast.success("Jurusan disimpan");
-    setOpen(false);
+    await router.invalidate();
   }
 
   return (

--- a/src/routes/_authenticated/admin.akademik.mata-kuliah.tsx
+++ b/src/routes/_authenticated/admin.akademik.mata-kuliah.tsx
@@ -1,7 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
-import { mataKuliahRepo, prodiRepo, semesterRepo, tahunAkademikRepo } from "@/lib/cbt/repos";
-import { mutateMataKuliahServer } from "@/lib/server/akademik/functions";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { useState, useEffect } from "react";
+import { mutateMataKuliahServer, getMataKuliahList, getProdiList, getSemesterList, getTahunAkademikList } from "@/lib/server/akademik/functions";
 import { uid } from "@/lib/cbt/storage";
 import type { MataKuliah } from "@/lib/cbt/types";
 import { Card, CardContent } from "@/components/ui/card";
@@ -26,14 +25,26 @@ import {
 } from "@/components/ui/select";
 
 export const Route = createFileRoute("/_authenticated/admin/akademik/mata-kuliah")({
+  loader: async () => {
+    const [items, prodiList, semesterList, taList] = await Promise.all([
+      getMataKuliahList(),
+      getProdiList(),
+      getSemesterList(),
+      getTahunAkademikList()
+    ]);
+    return { items, prodiList, semesterList, taList };
+  },
   component: MataKuliahPage,
 });
 
 function MataKuliahPage() {
-  const [items, setItems] = useState<MataKuliah[]>(mataKuliahRepo.all());
-  const prodiList = prodiRepo.all();
-  const semesterList = semesterRepo.all();
-  const taList = tahunAkademikRepo.all();
+  const router = useRouter();
+  const { items: initialItems, prodiList, semesterList, taList } = Route.useLoaderData();
+  const [items, setItems] = useState<MataKuliah[]>(initialItems);
+
+  useEffect(() => {
+    setItems(initialItems);
+  }, [initialItems]);
   
   const [editing, setEditing] = useState<MataKuliah | null>(null);
   const [open, setOpen] = useState(false);
@@ -53,14 +64,18 @@ function MataKuliahPage() {
 
   async function handleRemove(id: string) {
     if (!confirm("Hapus mata kuliah ini?")) return;
+    
+    // Optimistic UI
+    setItems((prev) => prev.filter((i) => i.id !== id));
+    
     const res = await mutateMataKuliahServer({ data: { action: "remove", payload: { id } } });
     if (!res.ok) {
       toast.error(res.error || "Gagal menghapus");
+      await router.invalidate();
       return;
     }
-    mataKuliahRepo.remove(id);
-    setItems(mataKuliahRepo.all());
     toast.success("Mata Kuliah dihapus");
+    await router.invalidate();
   }
 
   async function save() {
@@ -76,15 +91,27 @@ function MataKuliahPage() {
       prodiId: form.prodiId,
       semesterId: form.semesterId 
     };
+    
+    // Optimistic UI
+    setItems((prev) => {
+      const idx = prev.findIndex((i) => i.id === payload.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = payload;
+        return next;
+      }
+      return [...prev, payload];
+    });
+    setOpen(false);
+
     const res = await mutateMataKuliahServer({ data: { action: "upsert", payload } });
     if (!res.ok) {
       toast.error(res.error || "Gagal menyimpan");
+      await router.invalidate();
       return;
     }
-    mataKuliahRepo.upsert(payload);
-    setItems(mataKuliahRepo.all());
     toast.success("Mata Kuliah disimpan");
-    setOpen(false);
+    await router.invalidate();
   }
 
   return (

--- a/src/routes/_authenticated/admin.akademik.prodi.tsx
+++ b/src/routes/_authenticated/admin.akademik.prodi.tsx
@@ -1,7 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
-import { prodiRepo, jurusanRepo, fakultasRepo } from "@/lib/cbt/repos";
-import { mutateProdiServer } from "@/lib/server/akademik/functions";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { useState, useEffect } from "react";
+import { mutateProdiServer, getProdiList, getJurusanList, getFakultasList } from "@/lib/server/akademik/functions";
 import { uid } from "@/lib/cbt/storage";
 import type { ProgramStudi } from "@/lib/cbt/types";
 import { Card, CardContent } from "@/components/ui/card";
@@ -26,13 +25,25 @@ import {
 } from "@/components/ui/select";
 
 export const Route = createFileRoute("/_authenticated/admin/akademik/prodi")({
+  loader: async () => {
+    const [items, jurusanList, fakultasList] = await Promise.all([
+      getProdiList(),
+      getJurusanList(),
+      getFakultasList()
+    ]);
+    return { items, jurusanList, fakultasList };
+  },
   component: ProdiPage,
 });
 
 function ProdiPage() {
-  const [items, setItems] = useState<ProgramStudi[]>(prodiRepo.all());
-  const jurusanList = jurusanRepo.all();
-  const fakultasList = fakultasRepo.all();
+  const router = useRouter();
+  const { items: initialItems, jurusanList, fakultasList } = Route.useLoaderData();
+  const [items, setItems] = useState<ProgramStudi[]>(initialItems);
+
+  useEffect(() => {
+    setItems(initialItems);
+  }, [initialItems]);
   
   const [editing, setEditing] = useState<ProgramStudi | null>(null);
   const [open, setOpen] = useState(false);
@@ -52,14 +63,18 @@ function ProdiPage() {
 
   async function handleRemove(id: string) {
     if (!confirm("Hapus program studi ini?")) return;
+    
+    // Optimistic UI
+    setItems((prev) => prev.filter((i) => i.id !== id));
+    
     const res = await mutateProdiServer({ data: { action: "remove", payload: { id } } });
     if (!res.ok) {
       toast.error(res.error || "Gagal menghapus");
+      await router.invalidate();
       return;
     }
-    prodiRepo.remove(id);
-    setItems(prodiRepo.all());
     toast.success("Program Studi dihapus");
+    await router.invalidate();
   }
 
   async function save() {
@@ -68,15 +83,27 @@ function ProdiPage() {
       return;
     }
     const payload: ProgramStudi = { id: form.id, nama: form.nama.trim(), jurusanId: form.jurusanId };
+    
+    // Optimistic UI
+    setItems((prev) => {
+      const idx = prev.findIndex((i) => i.id === payload.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = payload;
+        return next;
+      }
+      return [...prev, payload];
+    });
+    setOpen(false);
+
     const res = await mutateProdiServer({ data: { action: "upsert", payload } });
     if (!res.ok) {
       toast.error(res.error || "Gagal menyimpan");
+      await router.invalidate();
       return;
     }
-    prodiRepo.upsert(payload);
-    setItems(prodiRepo.all());
     toast.success("Program Studi disimpan");
-    setOpen(false);
+    await router.invalidate();
   }
 
   return (

--- a/src/routes/_authenticated/admin.akademik.semester.tsx
+++ b/src/routes/_authenticated/admin.akademik.semester.tsx
@@ -1,7 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
-import { semesterRepo, tahunAkademikRepo } from "@/lib/cbt/repos";
-import { mutateSemesterServer } from "@/lib/server/akademik/functions";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { useState, useEffect } from "react";
+import { mutateSemesterServer, getSemesterList, getTahunAkademikList } from "@/lib/server/akademik/functions";
 import { uid } from "@/lib/cbt/storage";
 import type { Semester } from "@/lib/cbt/types";
 import { Card, CardContent } from "@/components/ui/card";
@@ -26,12 +25,24 @@ import {
 } from "@/components/ui/select";
 
 export const Route = createFileRoute("/_authenticated/admin/akademik/semester")({
+  loader: async () => {
+    const [items, taList] = await Promise.all([
+      getSemesterList(),
+      getTahunAkademikList()
+    ]);
+    return { items, taList };
+  },
   component: SemesterPage,
 });
 
 function SemesterPage() {
-  const [items, setItems] = useState<Semester[]>(semesterRepo.all());
-  const taList = tahunAkademikRepo.all();
+  const router = useRouter();
+  const { items: initialItems, taList } = Route.useLoaderData();
+  const [items, setItems] = useState<Semester[]>(initialItems);
+
+  useEffect(() => {
+    setItems(initialItems);
+  }, [initialItems]);
   
   const [editing, setEditing] = useState<Semester | null>(null);
   const [open, setOpen] = useState(false);
@@ -52,14 +63,18 @@ function SemesterPage() {
 
   async function handleRemove(id: string) {
     if (!confirm("Hapus semester ini?")) return;
+    
+    // Optimistic UI
+    setItems((prev) => prev.filter((i) => i.id !== id));
+    
     const res = await mutateSemesterServer({ data: { action: "remove", payload: { id } } });
     if (!res.ok) {
       toast.error(res.error || "Gagal menghapus");
+      await router.invalidate();
       return;
     }
-    semesterRepo.remove(id);
-    setItems(semesterRepo.all());
     toast.success("Semester dihapus");
+    await router.invalidate();
   }
 
   async function save() {
@@ -68,15 +83,27 @@ function SemesterPage() {
       return;
     }
     const payload: Semester = { id: form.id, nama: form.nama.trim(), tahunAkademikId: form.tahunAkademikId };
+    
+    // Optimistic UI
+    setItems((prev) => {
+      const idx = prev.findIndex((i) => i.id === payload.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = payload;
+        return next;
+      }
+      return [...prev, payload];
+    });
+    setOpen(false);
+
     const res = await mutateSemesterServer({ data: { action: "upsert", payload } });
     if (!res.ok) {
       toast.error(res.error || "Gagal menyimpan");
+      await router.invalidate();
       return;
     }
-    semesterRepo.upsert(payload);
-    setItems(semesterRepo.all());
     toast.success("Semester disimpan");
-    setOpen(false);
+    await router.invalidate();
   }
 
   return (

--- a/src/routes/_authenticated/admin.akademik.tahun-akademik.tsx
+++ b/src/routes/_authenticated/admin.akademik.tahun-akademik.tsx
@@ -1,7 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
-import { tahunAkademikRepo } from "@/lib/cbt/repos";
-import { mutateTahunAkademikServer } from "@/lib/server/akademik/functions";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { useState, useEffect } from "react";
+import { mutateTahunAkademikServer, getTahunAkademikList } from "@/lib/server/akademik/functions";
 import { uid } from "@/lib/cbt/storage";
 import type { TahunAkademik } from "@/lib/cbt/types";
 import { Card, CardContent } from "@/components/ui/card";
@@ -21,11 +20,20 @@ import { Switch } from "@/components/ui/switch";
 import { Badge } from "@/components/ui/badge";
 
 export const Route = createFileRoute("/_authenticated/admin/akademik/tahun-akademik")({
+  loader: async () => {
+    return await getTahunAkademikList();
+  },
   component: TahunAkademikPage,
 });
 
 function TahunAkademikPage() {
-  const [items, setItems] = useState<TahunAkademik[]>(tahunAkademikRepo.all());
+  const router = useRouter();
+  const initialItems = Route.useLoaderData();
+  const [items, setItems] = useState<TahunAkademik[]>(initialItems);
+  
+  useEffect(() => {
+    setItems(initialItems);
+  }, [initialItems]);
   
   const [editing, setEditing] = useState<TahunAkademik | null>(null);
   const [open, setOpen] = useState(false);
@@ -45,14 +53,18 @@ function TahunAkademikPage() {
 
   async function handleRemove(id: string) {
     if (!confirm("Hapus tahun akademik ini?")) return;
+    
+    // Optimistic UI
+    setItems((prev) => prev.filter((i) => i.id !== id));
+    
     const res = await mutateTahunAkademikServer({ data: { action: "remove", payload: { id } } });
     if (!res.ok) {
       toast.error(res.error || "Gagal menghapus");
+      await router.invalidate();
       return;
     }
-    tahunAkademikRepo.remove(id);
-    setItems(tahunAkademikRepo.all());
     toast.success("Tahun Akademik dihapus");
+    await router.invalidate();
   }
 
   async function save() {
@@ -61,15 +73,27 @@ function TahunAkademikPage() {
       return;
     }
     const payload: TahunAkademik = { id: form.id, nama: form.nama.trim(), aktif: form.aktif };
+    
+    // Optimistic UI
+    setItems((prev) => {
+      const idx = prev.findIndex((i) => i.id === payload.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = payload;
+        return next;
+      }
+      return [...prev, payload];
+    });
+    setOpen(false);
+
     const res = await mutateTahunAkademikServer({ data: { action: "upsert", payload } });
     if (!res.ok) {
       toast.error(res.error || "Gagal menyimpan");
+      await router.invalidate();
       return;
     }
-    tahunAkademikRepo.upsert(payload);
-    setItems(tahunAkademikRepo.all());
     toast.success("Tahun Akademik disimpan");
-    setOpen(false);
+    await router.invalidate();
   }
 
   return (


### PR DESCRIPTION
## Deskripsi
PR ini mengimplementasikan Fase 2 (Migrasi dari Global Cache ke Route-Level Data Fetching) untuk halaman Akademik (Fakultas, Jurusan, Prodi, Tahun Akademik, Semester, dan Mata Kuliah).

## Perubahan Utama:
1. Membuat RPC (server function) khusus untuk query data akademik (, dsb).
2. Memanfaatkan `loader` di TanStack Router sehingga tiap halaman hanya menarik data yang dibutuhkannya.
3. Mengurangi beban pada  dengan menghapus state repos dari UI Akademik.
4. Menambahkan Optimistic UI dan memanfaatkan `useRouter().invalidate()` setelah mutasi data.

Semua pengujian tipe (typecheck & lint) berjalan sukses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-backed loading for academic administration data, including faculties, departments, programs, academic years, semesters, and courses.
  * Academic management pages now load current data when opened.
  * Added optimistic updates for creating, editing, and deleting records.
* **Bug Fixes**
  * Failed changes now display an error notification and automatically refresh data to restore the correct server state.
  * Successful changes provide confirmation notifications and refresh displayed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->