### PR TITLE
fix: harden PR #19 follow-ups (scope operator, parseJson, a11y, PublicUser)

### DIFF
--- a/src/components/cbt/ThemeSwitcher.tsx
+++ b/src/components/cbt/ThemeSwitcher.tsx
@@ -11,7 +11,8 @@ export function ThemeSwitcher() {
       size="icon"
       onClick={toggleTheme}
       title={`Beralih ke Tema ${theme === "default" ? "Neobrutalism" : "Modern"}`}
-      aria-label="Ganti Template"
+      aria-label={`Beralih ke Tema ${theme === "default" ? "Neobrutalism" : "Modern"}`}
+      aria-pressed={theme === "neobrutalism"}
       className="h-10 w-10 border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] bg-background text-foreground shadow-[var(--neo-shadow)] transition-all hover:bg-[color:var(--neo-hover)] hover:translate-x-[2px] hover:translate-y-[2px]"
       style={{
         borderRadius: 'var(--neo-radius)'

--- a/src/lib/cbt/types.ts
+++ b/src/lib/cbt/types.ts
@@ -72,6 +72,7 @@ export const UserSchema = z.object({
 	createdAt: z.number(),
 });
 export type User = z.infer<typeof UserSchema>;
+export type PublicUser = Omit<User, "passwordHash">;
 
 
 // ---------------- Bank Soal ----------------

--- a/src/lib/server/sesi/functions.ts
+++ b/src/lib/server/sesi/functions.ts
@@ -12,7 +12,7 @@ import {
 } from "../db/auth";
 import type { SesiUjian, NavKey } from "@/lib/cbt/types";
 import { writeAuditLog } from "../db/audit";
-import { stringifyJson, toBigInt, toNumber } from "../db/json";
+import { stringifyJson, toBigInt, toNumber, parseJson } from "../db/json";
 import { getRequestIP } from "@tanstack/start-server-core";
 import { ipInRanges } from "@/lib/cbt/cidr";
 
@@ -211,9 +211,15 @@ export const getLiveOnlineSesis = createServerFn({ method: "GET" }).handler(
 			where: { status: "sedang" },
 			include: { peserta: true, ujian: true }
 		});
-		return rows.map((r: any) => {
-			const soalIds = typeof r.soalIds === "string" ? JSON.parse(r.soalIds) : r.soalIds || [];
-			const jawaban = typeof r.jawaban === "string" ? JSON.parse(r.jawaban) : r.jawaban || [];
+		// ponytail: super_admin sees all live sessions; operators only see ujian they can touch.
+		// If operator-all-read is intended by design, drop this filter.
+		const scoped: typeof rows = [];
+		for (const r of rows) {
+			if (caller.role === "super_admin" || await operatorCanTouchUjian(caller, r.ujianId)) scoped.push(r);
+		}
+		return scoped.map((r: any) => {
+			const soalIds = parseJson<string[]>(r.soalIds, []);
+			const jawaban = parseJson<any[]>(r.jawaban, []);
 			const dijawab = jawaban.filter((j: any) => (j.jawabanIds && j.jawabanIds.length > 0) || (j.jawabanEssay && j.jawabanEssay.length > 0)).length;
 			const totalSoal = soalIds.length || 1;
 			return {

--- a/src/lib/server/ujian/functions.ts
+++ b/src/lib/server/ujian/functions.ts
@@ -406,7 +406,7 @@ export const getFullConfigServer = createServerFn({ method: "GET" }).handler(
 			pesanLogin: row.pesanLogin,
 			mobileLock: row.mobileLock,
 			multiDevice: row.multiDevice,
-			roleAccess: typeof row.roleAccess === "string" ? JSON.parse(row.roleAccess) : row.roleAccess || {},
+			roleAccess: parseJson<Record<string, string[]>>(row.roleAccess, {}),
 		};
 	}
 );export const getUjiansList = createServerFn({ method: "GET" }).handler(

--- a/src/lib/server/users/functions.ts
+++ b/src/lib/server/users/functions.ts
@@ -4,9 +4,9 @@ import { prisma } from "../db/prisma";
 import { deleteSessionsForUser } from "../db/session";
 import { requireCaller, requireAdminResult, seedIfNeeded } from "../db/auth";
 import { hashPassword } from "@/lib/cbt/hash";
-import { stringifyJson } from "../db/json";
+import { stringifyJson, parseJson } from "../db/json";
 import { publicUser, upsertUserSchema } from "../repos/mappers";
-import type { User } from "@/lib/cbt/types";
+import type { User, PublicUser } from "@/lib/cbt/types";
 
 import { writeAuditLog } from "../db/audit";
 
@@ -186,7 +186,7 @@ export const mutateUserServer = createServerFn({ method: "POST" })
 	});
 
 export const getUsersList = createServerFn({ method: "GET" }).handler(
-	async () => {
+	async (): Promise<PublicUser[]> => {
 		const caller = await requireCaller();
 		if (!caller || caller.role !== "super_admin") return [];
 		const users = await prisma.user.findMany();
@@ -197,9 +197,8 @@ export const getUsersList = createServerFn({ method: "GET" }).handler(
 			role: u.role,
 			aktif: u.aktif,
 			unitId: u.unitId ?? undefined,
-			allowedTopikIds: typeof u.allowedTopikIds === "string" ? JSON.parse(u.allowedTopikIds) : u.allowedTopikIds || [],
-			mataKuliahIds: typeof u.mataKuliahIds === "string" ? JSON.parse(u.mataKuliahIds) : u.mataKuliahIds || [],
-			passwordHash: "",
+			allowedTopikIds: parseJson<string[]>(u.allowedTopikIds, []),
+			mataKuliahIds: parseJson<string[]>(u.mataKuliahIds, []),
 			detail: u.detail ?? undefined,
 			createdAt: Number(u.createdAt)
 		}));

--- a/src/routes/_authenticated/admin.pengaturan.tsx
+++ b/src/routes/_authenticated/admin.pengaturan.tsx
@@ -198,6 +198,7 @@ function PengaturanPage() {
             {/* Theme: Modern (Default) */}
             <button 
               onClick={() => setTheme("default")}
+              aria-pressed={theme === "default"}
               className={`text-left p-4 rounded-xl border-2 transition-all ${theme === "default" ? "border-primary ring-2 ring-primary/20 bg-primary/5" : "border-slate-200 dark:border-slate-800 hover:border-primary/50 bg-white dark:bg-slate-900"}`}
             >
               <div className="flex justify-between items-start mb-4">
@@ -214,6 +215,7 @@ function PengaturanPage() {
             {/* Theme: Neobrutalism */}
             <button 
               onClick={() => setTheme("neobrutalism")}
+              aria-pressed={theme === "neobrutalism"}
               className={`text-left p-4 rounded-none border-4 transition-all ${theme === "neobrutalism" ? "border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] bg-yellow-400/10" : "border-slate-200 dark:border-slate-800 hover:border-black bg-white dark:bg-slate-900"}`}
             >
               <div className="flex justify-between items-start mb-4">


### PR DESCRIPTION
Follow-up hardening for the server loaders + theme UI introduced in #19.

- `getLiveOnlineSesis`: scope operators to ujian they can touch (super_admin sees all)
- `getUsersList`: use `parseJson`; drop `passwordHash:""` placeholder; type `PublicUser[]`; add `PublicUser` DTO
- `getFullConfigServer`: use `parseJson` for `roleAccess`
- `ThemeSwitcher` + `admin.pengaturan`: `aria-pressed` + dynamic `aria-label` on theme buttons

Notes:
- `getModulsList`/`getTopiksList` not scoped (only called from `/admin/users/roles`, super_admin only).
- Side finding: `getUsersList` gates super_admin, so operators on `/admin/peserta` see an empty list — separate design decision.

Gates: lint (0 err / 3 warn ≤ 7), typecheck, unit, build — all green.