### PR TITLE
fix(ui): strip neobrutalism class from admin routes

### DIFF
--- a/src/routes/_authenticated/admin.analitik.$id.tsx
+++ b/src/routes/_authenticated/admin.analitik.$id.tsx
@@ -406,7 +406,7 @@ function ExamReportTab({ ujian, sesis }: { ujian: Ujian, sesis: SesiUjian[] }) {
     ]);
   }
   return (
-    <div className="space-y-6 neo-ready">
+    <div className="space-y-6 ">
       <div className="flex justify-between items-center">
         <div>
           <h2 className="text-xl font-semibold">Laporan Kelulusan</h2>
@@ -515,7 +515,7 @@ function AiInsightTab({ ujian, sesis }: { ujian: Ujian, sesis: SesiUjian[] }) {
   }
 
   return (
-    <div className="space-y-6 neo-ready">
+    <div className="space-y-6 ">
       <Card className="bg-white dark:bg-slate-950 border-slate-200 dark:border-slate-800 shadow-sm">
         <CardContent className="p-8 text-center space-y-4">
           <div className="mx-auto w-12 h-12 bg-slate-100 dark:bg-slate-900 rounded-full flex items-center justify-center mb-2">

--- a/src/routes/_authenticated/admin.analitik.analisis.tsx
+++ b/src/routes/_authenticated/admin.analitik.analisis.tsx
@@ -98,7 +98,7 @@ function AnalisisPage() {
   }
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-12 neo-ready">
+    <div className="mx-auto max-w-6xl space-y-6 pb-12 ">
 
       <div className="bg-gradient-to-br from-primary/10 via-primary/5 to-transparent p-6 rounded-xl border shadow-sm">
         <Link to="/admin/analitik" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors flex items-center gap-1 w-fit mb-3">

--- a/src/routes/_authenticated/admin.analitik.index.tsx
+++ b/src/routes/_authenticated/admin.analitik.index.tsx
@@ -24,7 +24,7 @@ export function AnalitikIndex() {
   const totalSelesai = semuaSesi.filter((s) => s.status === "selesai").length;
 
   return (
-    <AdminPage className="neo-ready">
+    <AdminPage className="">
       <AdminPageHeader
         title="Analisis & Hasil"
         description="Ringkasan aktivitas ujian, laporan hasil, dan peringkat kelas."

--- a/src/routes/_authenticated/admin.analitik.rekap.tsx
+++ b/src/routes/_authenticated/admin.analitik.rekap.tsx
@@ -88,7 +88,7 @@ function RekapPage() {
   }
 
   return (
-    <div className="space-y-6 pb-12 neo-ready">
+    <div className="space-y-6 pb-12 ">
       <div className="bg-gradient-to-br from-primary/10 via-primary/5 to-transparent p-6 rounded-xl border shadow-sm">
         <Link to="/admin/analitik" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors flex items-center gap-1 w-fit mb-3">
           ← Kembali ke daftar analitik

--- a/src/routes/_authenticated/admin.evaluasi.$id.tsx
+++ b/src/routes/_authenticated/admin.evaluasi.$id.tsx
@@ -82,7 +82,7 @@ function EvaluasiSesi() {
         </p>
       </div>
 
-      <div className="space-y-6 neo-ready">
+      <div className="space-y-6 ">
         {items.map(({ j, idx, soal }) => {
           const isGraded = typeof j.skor === 'number';
           

--- a/src/routes/_authenticated/admin.evaluasi.index.tsx
+++ b/src/routes/_authenticated/admin.evaluasi.index.tsx
@@ -63,7 +63,7 @@ function EvaluasiList() {
   const totalBelumEssay = items.reduce((acc, curr) => acc + curr.belumEssay, 0);
 
   return (
-    <AdminPage className="neo-ready">
+    <AdminPage className="">
       <AdminPageHeader
         title="Penilaian Essay"
         description="Pilih ujian untuk mulai memeriksa dan memberikan nilai pada jawaban essay."

--- a/src/routes/_authenticated/admin.evaluasi.ujian.$id.tsx
+++ b/src/routes/_authenticated/admin.evaluasi.ujian.$id.tsx
@@ -48,7 +48,7 @@ function EvaluasiUjianList() {
   const totalBelum = items.reduce((acc, curr) => acc + curr.belum, 0);
 
   return (
-    <div className="space-y-6 max-w-6xl mx-auto pb-12 neo-ready">
+    <div className="space-y-6 max-w-6xl mx-auto pb-12 ">
       <div className="mb-4">
         <Link to="/admin/evaluasi" className="inline-flex items-center gap-1 text-sm font-bold text-slate-500 hover:text-slate-900 dark:hover:text-slate-100 transition-colors">
           ← Kembali ke Penilaian Essay

--- a/src/routes/_authenticated/admin.files.tsx
+++ b/src/routes/_authenticated/admin.files.tsx
@@ -77,7 +77,7 @@ function FilesPage() {
   });
 
   return (
-    <AdminPage className="neo-ready">
+    <AdminPage className="">
       
       <AdminPageHeader
         title="Drive Penyimpanan"

--- a/src/routes/_authenticated/admin.leaderboard.$id.tsx
+++ b/src/routes/_authenticated/admin.leaderboard.$id.tsx
@@ -21,7 +21,7 @@ function Leaderboard() {
   const users = usersRepo.all();
 
   return (
-    <div className="space-y-4 max-w-3xl neo-ready">
+    <div className="space-y-4 max-w-3xl ">
       <div>
         <Link to="/admin/ujian" className="text-sm text-muted-foreground hover:underline">← Paket ujian</Link>
         <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2"><Trophy className="h-6 w-6 text-warning" />Leaderboard — {ujian.nama}</h1>

--- a/src/routes/_authenticated/admin.leaderboard.index.tsx
+++ b/src/routes/_authenticated/admin.leaderboard.index.tsx
@@ -13,7 +13,7 @@ function LeaderboardIndex() {
   const sesi = sesiRepo.all();
 
   return (
-    <AdminPage className="neo-ready">
+    <AdminPage className="">
       <div className="max-w-4xl pb-20 w-full">
       <AdminPageHeader
         title="Leaderboard"

--- a/src/routes/_authenticated/admin.modul.$id.topik.tsx
+++ b/src/routes/_authenticated/admin.modul.$id.topik.tsx
@@ -46,7 +46,7 @@ function TopikPage() {
   }
 
   return (
-    <div className="max-w-6xl mx-auto space-y-10 animate-in fade-in duration-500 pb-12 pt-4 neo-ready">
+    <div className="max-w-6xl mx-auto space-y-10 animate-in fade-in duration-500 pb-12 pt-4 ">
       {/* Header Section */}
       <div className="flex flex-col gap-4 md:flex-row md:items-end justify-between border-b border-slate-200 dark:border-white/10 pb-6">
         <div className="space-y-1">

--- a/src/routes/_authenticated/admin.modul.import-word.tsx
+++ b/src/routes/_authenticated/admin.modul.import-word.tsx
@@ -94,7 +94,7 @@ function ImportWord() {
 
   if (moduls.length === 0 || topiks.length === 0) {
     return (
-      <div className="max-w-5xl space-y-4 neo-ready">
+      <div className="max-w-5xl space-y-4 ">
         <div>
           <Link to="/admin/modul" className="text-sm text-muted-foreground hover:underline">
             ← Modul
@@ -158,7 +158,7 @@ function ImportWord() {
   }
 
   return (
-    <div className="max-w-5xl space-y-4 neo-ready">
+    <div className="max-w-5xl space-y-4 ">
       <div>
         <Link to="/admin/modul" className="text-sm text-muted-foreground hover:underline">
           ← Modul

--- a/src/routes/_authenticated/admin.modul.import.tsx
+++ b/src/routes/_authenticated/admin.modul.import.tsx
@@ -35,7 +35,7 @@ function ImportPage() {
 
   if (moduls.length === 0 || topiks.length === 0) {
     return (
-      <div className="space-y-4 max-w-5xl neo-ready">
+      <div className="space-y-4 max-w-5xl ">
         <div>
           <Link to="/admin/modul" className="text-sm text-muted-foreground hover:underline">
             ← Modul
@@ -229,7 +229,7 @@ function ImportPage() {
   }
 
   return (
-    <div className="space-y-4 max-w-5xl neo-ready">
+    <div className="space-y-4 max-w-5xl ">
       <div>
         <Link to="/admin/modul" className="text-sm text-muted-foreground hover:underline">
           ← Modul

--- a/src/routes/_authenticated/admin.modul.tsx
+++ b/src/routes/_authenticated/admin.modul.tsx
@@ -130,7 +130,7 @@ function ModulPage() {
   }
 
   return (
-    <AdminPage className="neo-ready">
+    <AdminPage className="">
       <AdminPageHeader
         title="Bank Soal (Modul)"
         description="Pusat penyimpanan referensi soal-soal ujian berdasarkan mata kuliah."

--- a/src/routes/_authenticated/admin.panduan.tsx
+++ b/src/routes/_authenticated/admin.panduan.tsx
@@ -46,7 +46,7 @@ function PanduanPage() {
   }, []);
 
   return (
-    <AdminPage className="neo-ready">
+    <AdminPage className="">
       <AdminPageHeader
         title="Panduan Penggunaan"
         description={`Referensi lengkap ${cfg.appName} — dari pembuatan soal hingga evaluasi hasil.`}

--- a/src/routes/_authenticated/admin.pengaturan.tsx
+++ b/src/routes/_authenticated/admin.pengaturan.tsx
@@ -62,7 +62,7 @@ function PengaturanPage() {
   }
 
   return (
-    <AdminPage className="neo-ready">
+    <AdminPage className="">
       <AdminPageHeader
         title="Pengaturan Aplikasi"
         description="Konfigurasi institusi, keamanan, browser ujian, dan branding CBT."

--- a/src/routes/_authenticated/admin.peserta.index.tsx
+++ b/src/routes/_authenticated/admin.peserta.index.tsx
@@ -120,7 +120,7 @@ function PesertaPage() {
   }
 
   return (
-        <AdminPage className="neo-ready">
+        <AdminPage className="">
 
       <AdminPageHeader
         title="Akun Peserta"

--- a/src/routes/_authenticated/admin.peserta.kartu.tsx
+++ b/src/routes/_authenticated/admin.peserta.kartu.tsx
@@ -30,7 +30,7 @@ function KartuPage() {
   const appName = config?.appName || "CBT-MAN";
 
   return (
-    <AdminPage className="neo-ready">
+    <AdminPage className="">
       <div className="flex items-center justify-between gap-2 print:hidden">
         <AdminPageHeader
           title="Cetak Kartu Peserta"

--- a/src/routes/_authenticated/admin.peserta.online.tsx
+++ b/src/routes/_authenticated/admin.peserta.online.tsx
@@ -69,7 +69,7 @@ function OnlinePage() {
   }, [search, rawSesis]);
 
   return (
-    <AdminPage className="neo-ready">
+    <AdminPage className="">
       
       {/* Header */}
       <AdminPageHeader

--- a/src/routes/_authenticated/admin.tools.tsx
+++ b/src/routes/_authenticated/admin.tools.tsx
@@ -90,7 +90,7 @@ function ToolsPage() {
   }
 
   return (
-    <AdminPage className="neo-ready">
+    <AdminPage className="">
 
       <AdminPageHeader
         title="Alat Sistem"

--- a/src/routes/_authenticated/admin.topik.$id.soal.tsx
+++ b/src/routes/_authenticated/admin.topik.$id.soal.tsx
@@ -64,7 +64,7 @@ function SoalPage() {
   );
 
   return (
-    <div className="relative min-h-screen neo-ready">
+    <div className="relative min-h-screen ">
       {/* Subtle radial glow background */}
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,_var(--tw-gradient-stops))] from-indigo-50/50 via-white to-white dark:from-indigo-950/20 dark:via-zinc-950 dark:to-zinc-950 -z-10" />
       

--- a/src/routes/_authenticated/admin.ujian.$id.peserta.tsx
+++ b/src/routes/_authenticated/admin.ujian.$id.peserta.tsx
@@ -33,7 +33,7 @@ function PesertaUjian() {
 
 
   return (
-    <div className="max-w-4xl space-y-4 neo-ready">
+    <div className="max-w-4xl space-y-4 ">
       <div className="flex items-start justify-between">
         <div>
           <Link to="/admin/ujian" className="text-sm text-muted-foreground hover:underline">

--- a/src/routes/_authenticated/admin.ujian.$id.token.tsx
+++ b/src/routes/_authenticated/admin.ujian.$id.token.tsx
@@ -147,7 +147,7 @@ function TokenPage() {
   if (!ujian) return <div>Tidak ditemukan</div>;
 
   return (
-    <div className="max-w-3xl space-y-4 neo-ready">
+    <div className="max-w-3xl space-y-4 ">
       <div>
         <Link to="/admin/ujian" className="text-sm text-muted-foreground hover:underline">
           ← Paket ujian

--- a/src/routes/_authenticated/admin.ujian.$id.tsx
+++ b/src/routes/_authenticated/admin.ujian.$id.tsx
@@ -230,7 +230,7 @@ function UjianEditor() {
   }
 
   return (
-    <div className="space-y-4 max-w-4xl neo-ready">
+    <div className="space-y-4 max-w-4xl ">
       <div className="flex items-center justify-between">
         <div>
           <Link to="/admin/ujian" className="text-sm text-muted-foreground hover:underline">

--- a/src/routes/_authenticated/admin.ujian.tsx
+++ b/src/routes/_authenticated/admin.ujian.tsx
@@ -160,7 +160,7 @@ function UjianList() {
     activeTab === "selesai" ? selesai : filteredList;
 
   return (
-    <AdminPage className="neo-ready">
+    <AdminPage className="">
       
       <AdminPageHeader
         title="Manajemen Paket Ujian"


### PR DESCRIPTION
Remove hardcoded neo-ready classes that mistakenly activated neobrutalism on the clean modern dashboard.