### PR TITLE
feat: improve admin sidebar and header

### DIFF
--- a/src/routes/_authenticated/admin.tsx
+++ b/src/routes/_authenticated/admin.tsx
@@ -1,4 +1,3 @@
-
 import React, { useState, useEffect } from "react";
 import {
   createFileRoute,
@@ -12,17 +11,16 @@ import { useAuthStore } from "@/lib/cbt/auth-store";
 import { configRepo, hydrateRepos } from "@/lib/cbt/repos";
 import { type AppConfig, type NavKey, type Role } from "@/lib/cbt/types";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   LayoutDashboard,
   Users,
   GraduationCap,
   BookOpen,
   FileText,
-  ClipboardList,
   BarChart3,
   Settings,
   LogOut,
-  Trophy,
   Wrench,
   FolderOpen,
   PenLine,
@@ -32,9 +30,7 @@ import {
   Moon,
   Menu,
   X,
-  Sparkles,
   BookOpenCheck,
-
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -72,7 +68,7 @@ type NavGroup = {
 
 const navGroups: NavGroup[] = [
   {
-    label: "Main",
+    label: "Utama",
     items: [
       { to: "/admin", label: "Dashboard", icon: LayoutDashboard, exact: true },
     ]
@@ -89,7 +85,6 @@ const navGroups: NavGroup[] = [
     label: "Bank Soal & Berkas",
     items: [
       { to: "/admin/modul", label: "Bank Soal", icon: BookOpen },
-
       { to: "/admin/files", label: "File Manager", icon: FolderOpen },
     ]
   },
@@ -97,7 +92,6 @@ const navGroups: NavGroup[] = [
     label: "Ujian & Pelaksanaan",
     items: [
       { to: "/admin/ujian", label: "Paket Ujian", icon: FileText },
-
       { to: "/admin/peserta/online", label: "Pantau Ujian Live", icon: Activity },
     ]
   },
@@ -114,14 +108,11 @@ const navGroups: NavGroup[] = [
       { to: "/admin/pengaturan", label: "Pengaturan", icon: Settings },
       { to: "/admin/tools", label: "Backup & Tools", icon: Wrench },
       { to: "/admin/panduan", label: "Panduan", icon: BookOpenCheck },
-
     ]
   }
 ];
 
-// Keep a flattened version for logic checks
 const navItems: NavItem[] = navGroups.flatMap(g => g.items);
-
 
 function normalizedAdminPath(pathname: string) {
   if (pathname === "/admin") return pathname;
@@ -185,8 +176,6 @@ function AdminLayout() {
   const cfg = configRepo.get();
   const appName = cfg.appName;
 
-  const visible = navItems.filter((item) => canAccessAdminPath(user, item.to, cfg));
-
   const [theme, setTheme] = useState("light");
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
@@ -211,129 +200,126 @@ function AdminLayout() {
     else document.documentElement.classList.remove("dark");
   };
 
-  // Close mobile menu on route change
   useEffect(() => {
     setMobileMenuOpen(false);
   }, [pathname]);
 
   return (
-    <div className="min-h-screen bg-muted/30">
+    <div className="min-h-screen bg-slate-50/50 dark:bg-slate-950 text-slate-900 dark:text-slate-100">
       <div className="flex">
         
         {/* Mobile Menu Overlay */}
         {mobileMenuOpen && (
           <div 
-            className="fixed inset-0 z-40 bg-black/50 lg:hidden backdrop-blur-sm"
+            className="fixed inset-0 z-40 bg-slate-900/40 lg:hidden backdrop-blur-sm transition-opacity"
             onClick={() => setMobileMenuOpen(false)}
           />
         )}
 
         {/* Sidebar */}
         <aside className={cn(
-          "w-72 shrink-0 border-r-[length:var(--neo-border-width)] border-r-[color:var(--neo-border-color)] bg-white text-[color:var(--neo-text)] lg:block transition-transform duration-300 z-50 lg:sticky lg:top-0 lg:h-screen lg:overflow-y-auto scrollbar-thin",
-          mobileMenuOpen ? "fixed inset-y-0 left-0 h-screen overflow-y-auto shadow-[var(--neo-shadow)]" : "hidden"
-        )}>
-          <div className="flex h-16 items-center justify-between border-b-[length:var(--neo-border-width)] border-b-[color:var(--neo-border-color)] px-5 font-black uppercase tracking-wider text-xl bg-white">
-            <div className="flex items-center gap-3">
-              {cfg.appLogo ? (
-                <img src={cfg.appLogo} alt="Logo" className="h-8 w-auto object-contain" />
-              ) : (
-                <span className="grid h-9 w-9 place-items-center bg-[color:var(--neo-accent)] border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] shadow-[var(--neo-shadow)] text-[color:var(--neo-text)] text-lg">
-                  Z
-                </span>
+            "w-64 shrink-0 border-r border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 lg:block transition-transform duration-200 z-50 lg:sticky lg:top-0 lg:h-screen lg:overflow-y-auto scrollbar-thin",
+            mobileMenuOpen ? "fixed inset-y-0 left-0 h-screen overflow-y-auto shadow-xl" : "hidden"
+          )}>
+            <div className="flex h-16 items-center justify-between border-b border-slate-200 dark:border-slate-800 px-5">
+              <div className="flex items-center gap-3">
+                {cfg.appLogo ? (
+                  <img src={cfg.appLogo} alt="Logo" className="h-7 w-auto object-contain" />
+                ) : (
+                  <span className="grid h-8 w-8 place-items-center rounded-lg bg-primary text-primary-foreground font-bold text-base shadow-sm">
+                    Z
+                  </span>
+                )}
+                <span className="font-bold text-slate-900 dark:text-slate-100 text-base tracking-tight truncate">{appName}</span>
+              </div>
+              {mobileMenuOpen && (
+                <Button variant="ghost" size="icon" className="lg:hidden h-8 w-8 text-slate-500 hover:text-slate-900" onClick={() => setMobileMenuOpen(false)}>
+                  <X className="h-5 w-5" />
+                </Button>
               )}
-              <span className="truncate">{appName}</span>
             </div>
-            {mobileMenuOpen && (
-              <Button variant="ghost" size="icon" title="Tutup menu navigasi" aria-label="Tutup menu navigasi" className="lg:hidden h-8 w-8 border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] hover:bg-[color:var(--neo-bg)] bg-white shadow-[var(--neo-shadow)] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none rounded-[var(--neo-radius)]" onClick={() => setMobileMenuOpen(false)}>
-                <X className="h-5 w-5 stroke-[3]" />
-              </Button>
-            )}
-          </div>
-          <nav className="flex flex-col gap-8 p-6">
-            {navGroups.map((group) => {
-              const visibleItems = group.items.filter((item) =>
-                canAccessAdminPath(user, item.to, cfg)
-              );
+            <nav className="flex flex-col gap-6 p-4">
+              {navGroups.map((group) => {
+                const visibleItems = group.items.filter((item) =>
+                  canAccessAdminPath(user, item.to, cfg)
+                );
 
-              if (visibleItems.length === 0) return null;
+                if (visibleItems.length === 0) return null;
 
-              return (
-                <div key={group.label} className="flex flex-col gap-4">
-                  <h3 className="w-full text-center px-3 py-2 text-xs font-black uppercase tracking-wider text-[color:var(--neo-text)] bg-[color:var(--neo-bg)] border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] shadow-[var(--neo-shadow)]">
-                    {group.label}
-                  </h3>
-                  <div className="flex flex-col gap-3">
-                    {visibleItems.map((n) => {
-                      const Icon = n.icon;
-                      return (
-                        <Link
-                          key={n.to}
-                          to={n.to as never}
-                          activeOptions={{ exact: n.exact }}
-                          activeProps={{
-                            className: "bg-[color:var(--neo-accent)] text-[color:var(--neo-text)] translate-x-[4px] translate-y-[4px] shadow-[var(--neo-shadow)]"
-                          }}
-                          inactiveProps={{
-                            className: "bg-white text-[color:var(--neo-text)] shadow-[var(--neo-shadow)] hover:bg-[color:var(--neo-bg)] hover:text-[color:var(--neo-text)] hover:translate-x-[4px] hover:translate-y-[4px] hover:shadow-[var(--neo-shadow)]"
-                          }}
-                          className="flex items-center gap-3 border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] px-4 py-3 text-xs md:text-sm font-black uppercase tracking-wider transition-all duration-100 ease-in-out rounded-[var(--neo-radius)]"
-                        >
-                          <Icon className="h-5 w-5 stroke-[2.5] shrink-0" />
-                          <span className="leading-snug">{n.label}</span>
-                        </Link>
-                      );
-                    })}
+                return (
+                  <div key={group.label} className="flex flex-col gap-1.5">
+                    <h3 className="px-3 text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+                      {group.label}
+                    </h3>
+                    <div className="flex flex-col gap-1">
+                      {visibleItems.map((n) => {
+                        const Icon = n.icon;
+                        return (
+                          <Link
+                            key={n.to}
+                            to={n.to as never}
+                            activeOptions={{ exact: n.exact }}
+                            activeProps={{
+                              className: "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900 font-semibold shadow-sm"
+                            }}
+                            inactiveProps={{
+                              className: "text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-100"
+                            }}
+                            className="flex items-center gap-3 px-3 py-2 text-xs md:text-sm rounded-lg transition-colors duration-150"
+                          >
+                            <Icon className="h-4 w-4 shrink-0" />
+                            <span className="leading-snug">{n.label}</span>
+                          </Link>
+                        );
+                      })}
+                    </div>
                   </div>
-                </div>
-              );
-            })}
-          </nav>
-        </aside>
+                );
+              })}
+            </nav>
+          </aside>
 
         <div className="flex min-h-screen flex-1 flex-col min-w-0">
 
-          <header className="flex h-16 items-center justify-between border-b-[length:var(--neo-border-width)] border-b-[color:var(--neo-border-color)] bg-white px-4 lg:px-6 sticky top-0 z-30">
+          <header className="flex h-16 items-center justify-between border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 backdrop-blur-md px-4 lg:px-6 sticky top-0 z-30">
             <div className="flex items-center gap-4">
               <Button
                 variant="ghost"
                 size="icon"
                 title="Buka menu navigasi"
                 aria-label="Buka menu navigasi"
-                className="lg:hidden h-10 w-10 border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] bg-[color:var(--neo-bg)] hover:bg-[color:var(--neo-accent)] shadow-[var(--neo-shadow)] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[var(--neo-shadow)] rounded-[var(--neo-radius)]"
+                className="lg:hidden h-9 w-9 text-slate-500 hover:text-slate-900"
                 onClick={() => setMobileMenuOpen(true)}
               >
-                <Menu className="h-6 w-6 stroke-[3] text-[color:var(--neo-text)]" />
+                <Menu className="h-5 w-5" />
               </Button>
-              <div className="text-sm hidden sm:flex items-center gap-4">
-                <span className="font-black uppercase text-[color:var(--neo-text)] text-base">{user.namaLengkap}</span>
-                <span className="border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] bg-[color:var(--neo-accent)] px-2 py-0.5 text-xs font-black uppercase text-[color:var(--neo-text)] shadow-[var(--neo-shadow)]">
+              <div className="text-sm hidden sm:flex items-center gap-3">
+                <span className="font-semibold text-slate-900 dark:text-slate-100 text-sm">{user.namaLengkap}</span>
+                <Badge variant="outline" className="font-medium text-[11px] uppercase border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 text-slate-600 dark:text-slate-400">
                   {user.role}
-                </span>
+                </Badge>
               </div>
             </div>
-            <div className="flex items-center gap-5">
+            <div className="flex items-center gap-3">
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-10 w-10 rounded-[var(--neo-radius)] border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] bg-white shadow-[var(--neo-shadow)] hover:bg-[color:var(--neo-bg)] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[var(--neo-shadow)]"
+                className="h-9 w-9 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
                 onClick={toggleTheme}
                 title="Ganti tema"
-                aria-label="Ganti tema"
               >
-                {theme === "dark" ? <Sun className="h-5 w-5 stroke-[3] text-[color:var(--neo-text)]" /> : <Moon className="h-5 w-5 stroke-[3] text-[color:var(--neo-text)]" />}
+                {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
               </Button>
               <Button
                 variant="outline"
-                title="Keluar"
-                aria-label="Keluar"
-                className="h-10 rounded-[var(--neo-radius)] border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] bg-white font-black uppercase text-[color:var(--neo-text)] shadow-[var(--neo-shadow)] hover:bg-red-400 hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[var(--neo-shadow)]"
+                size="sm"
+                className="h-9 text-xs font-medium border-slate-200 dark:border-slate-800 hover:bg-rose-50 dark:hover:bg-rose-950/50 hover:text-rose-600 dark:hover:text-rose-400 hover:border-rose-200 dark:hover:border-rose-900 transition-colors"
                 onClick={async () => {
                   await logout();
                   navigate({ to: "/login" });
                 }}
               >
-                <LogOut className="mr-2 h-5 w-5 stroke-[3]" /> <span className="hidden sm:inline">Keluar</span>
+                <LogOut className="mr-1.5 h-3.5 w-3.5" /> <span className="hidden sm:inline">Keluar</span>
               </Button>
             </div>
           </header>

--- a/src/routes/_authenticated/admin.tsx
+++ b/src/routes/_authenticated/admin.tsx
@@ -233,7 +233,7 @@ function AdminLayout() {
                 <span className="font-bold text-slate-900 dark:text-slate-100 text-base tracking-tight truncate">{appName}</span>
               </div>
               {mobileMenuOpen && (
-                <Button variant="ghost" size="icon" className="lg:hidden h-8 w-8 text-slate-500 hover:text-slate-900" onClick={() => setMobileMenuOpen(false)}>
+                <Button variant="ghost" size="icon" title="Tutup menu navigasi" aria-label="Tutup menu navigasi" className="lg:hidden h-8 w-8 text-slate-500 hover:text-slate-900" onClick={() => setMobileMenuOpen(false)}>
                   <X className="h-5 w-5" />
                 </Button>
               )}


### PR DESCRIPTION
Supersedes the isolated sidebar portion of #62. Reviewed extraction: only `src/routes/_authenticated/admin.tsx`; retains the global sidebar on Panduan and existing access rules.