### PR TITLE
feat(admin-akademik): Enhance academic unit UX with human layout, inline adding, and icon detail panel

### DIFF
--- a/src/routes/_authenticated/admin.akademik.index.tsx
+++ b/src/routes/_authenticated/admin.akademik.index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { unitAkademikRepo } from "@/lib/cbt/repos";
 import { mutateUnitAkademikServer } from "@/lib/server/akademik/functions";
 import type { UnitAkademik } from "@/lib/cbt/types";
@@ -34,6 +34,7 @@ function UnitAkademikExplorer() {
   const [units, setUnits] = useState<UnitAkademik[]>(unitAkademikRepo.all());
   const [search, setSearch] = useState("");
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // Form State
   const [editing, setEditing] = useState<UnitAkademik | null>(null);
@@ -154,6 +155,7 @@ function UnitAkademikExplorer() {
                     onClick={() => {
                       setEditing(u);
                       setForm({ nama: u.nama, tipe: u.tipe, parentId: u.parentId || "none" });
+                      setTimeout(() => inputRef.current?.focus(), 50);
                     }}
                   >
                     <Edit2 className="h-3.5 w-3.5" />
@@ -168,10 +170,12 @@ function UnitAkademikExplorer() {
                     title="Tambah Sub-Unit"
                     onClick={() => {
                       setEditing(null);
-                      setForm({ nama: "", tipe: "kelas", parentId: u.id });
+                      const nextType = u.tipe === "fakultas" ? "prodi" : "kelas";
+                      setForm({ nama: "", tipe: nextType, parentId: u.id });
                       const next = new Set(expanded);
                       next.add(u.id);
                       setExpanded(next);
+                      setTimeout(() => inputRef.current?.focus(), 50);
                     }}
                   >
                     <Plus className="h-3.5 w-3.5" />
@@ -186,13 +190,11 @@ function UnitAkademikExplorer() {
     );
   };
 
-  const parentName = form.parentId !== "none" ? units.find((u: UnitAkademik) => u.id === form.parentId)?.nama : null;
-
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
       <Card className="md:col-span-2">
         <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between space-y-4 sm:space-y-0 pb-4">
-          <CardTitle>Hierarki Kelas & Jurusan</CardTitle>
+          <CardTitle>Struktur Unit Akademik</CardTitle>
           <Input
             placeholder="Cari unit..."
             className="max-w-xs"
@@ -212,8 +214,8 @@ function UnitAkademikExplorer() {
             {units.length === 0 ? (
               <div className="flex h-[300px] flex-col items-center justify-center text-muted-foreground">
                 <Folder className="mb-2 h-10 w-10 opacity-20" />
-                <p>Belum ada hierarki rombongan belajar atau jurusan.</p>
-                <Button variant="link" onClick={() => setForm({ ...form, parentId: "none" })}>Buat Tingkat Pertama (Root)</Button>
+                <p>Belum ada data unit akademik.</p>
+                <Button variant="link" onClick={() => setForm({ ...form, parentId: "none" })}>Buat Unit Utama (Fakultas)</Button>
               </div>
             ) : (
               renderTree(null, 0)
@@ -225,44 +227,39 @@ function UnitAkademikExplorer() {
       <div className="space-y-4">
         <Card>
           <CardHeader>
-            <CardTitle>{editing ? "Edit Rombel/Jurusan" : form.parentId !== "none" ? "Tambah Sub-Kelas" : "Tambah Kelas/Jurusan"}</CardTitle>
-            {!editing && parentName && (
-              <div className="bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 text-xs px-3 py-2 rounded-md border border-blue-200 dark:border-blue-800 mt-2 flex items-center gap-2 font-medium">
-                <div className="h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
-                Menambahkan di dalam: <strong>{parentName}</strong>
-              </div>
-            )}
+            <CardTitle>{editing ? "Edit Unit Akademik" : "Tambah Unit Akademik"}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-1.5">
-              <Label>Nama Kelompok / Rombel</Label>
+              <Label>Nama Unit Akademik</Label>
               <Input
-                placeholder="Contoh: Kelas X MIPA 1, atau Teknik Informatika"
+                ref={inputRef}
+                placeholder="Contoh: Fakultas Ilmu Komputer / S1 Teknik Informatika"
                 value={form.nama}
                 onChange={(e) => setForm({ ...form, nama: e.target.value })}
               />
             </div>
             <div className="space-y-1.5">
-              <Label>Tingkatan</Label>
+              <Label>Tipe Unit</Label>
               <Select value={form.tipe} onValueChange={(val) => setForm({ ...form, tipe: val })}>
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="fakultas">Fakultas / Gedung Rayon</SelectItem>
-                  <SelectItem value="prodi">Jurusan / Program Studi</SelectItem>
-                  <SelectItem value="kelas">Rombel / Kelas Paralel</SelectItem>
+                  <SelectItem value="fakultas">Fakultas</SelectItem>
+                  <SelectItem value="prodi">Program Studi / Jurusan</SelectItem>
+                  <SelectItem value="kelas">Kelas / Angkatan</SelectItem>
                 </SelectContent>
               </Select>
             </div>
             <div className="space-y-1.5">
-              <Label>Berada di bawah (Tingkat Induk)</Label>
+              <Label>Unit Induk (Parent)</Label>
               <Select value={form.parentId} onValueChange={(val) => setForm({ ...form, parentId: val })}>
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="none">-- Sebagai Tingkat Utama (Root) --</SelectItem>
+                  <SelectItem value="none">-- Tanpa Induk (Fakultas / Utama) --</SelectItem>
                   {allowedParentUnits.map((u: UnitAkademik) => (
                     <SelectItem key={u.id} value={u.id}>{u.nama} ({u.tipe})</SelectItem>
                   ))}
@@ -271,8 +268,8 @@ function UnitAkademikExplorer() {
             </div>
             
             <div className="flex gap-2 pt-2">
-              <Button onClick={save} className="flex-1">{editing ? "Simpan Perubahan" : "Tambahkan"}</Button>
-              {(editing || form.nama || form.parentId !== "none") && <Button variant="outline" onClick={resetForm}>Batal</Button>}
+              <Button onClick={save} className="flex-1">{editing ? "Simpan Perubahan" : "Tambah Unit"}</Button>
+              {(editing || form.nama || form.parentId !== "none") && <Button variant="outline" onClick={resetForm}>Reset</Button>}
             </div>
           </CardContent>
         </Card>

--- a/src/routes/_authenticated/admin.akademik.index.tsx
+++ b/src/routes/_authenticated/admin.akademik.index.tsx
@@ -30,6 +30,20 @@ function getDescendantIds(targetId: string, units: UnitAkademik[]): Set<string> 
   return set;
 }
 
+function highlightText(text: string, query: string) {
+  if (!query.trim()) return text;
+  const parts = text.split(new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi"));
+  return parts.map((part, i) =>
+    part.toLowerCase() === query.toLowerCase() ? (
+      <mark key={i} className="bg-amber-200 dark:bg-amber-900/80 dark:text-amber-100 font-semibold px-0.5 rounded">
+        {part}
+      </mark>
+    ) : (
+      part
+    )
+  );
+}
+
 function UnitAkademikExplorer() {
   const [units, setUnits] = useState<UnitAkademik[]>(unitAkademikRepo.all());
   const [search, setSearch] = useState("");
@@ -39,6 +53,10 @@ function UnitAkademikExplorer() {
   // Form State
   const [editing, setEditing] = useState<UnitAkademik | null>(null);
   const [form, setForm] = useState({ nama: "", tipe: "fakultas", parentId: "none" });
+
+  const filteredMatchCount = search.trim()
+    ? units.filter((u: UnitAkademik) => u.nama.toLowerCase().includes(search.toLowerCase())).length
+    : units.length;
 
   const toggleExpand = (id: string) => {
     const next = new Set(expanded);
@@ -145,7 +163,7 @@ function UnitAkademikExplorer() {
                   )}
                 </div>
                 {getIcon(u.tipe)}
-                <span className="flex-1 text-sm font-medium">{u.nama}</span>
+                <span className="flex-1 text-sm font-medium">{highlightText(u.nama, search)}</span>
                 <span className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground uppercase">{u.tipe}</span>
                 
                 <div className="flex items-center gap-1 opacity-50 hover:opacity-100">
@@ -225,19 +243,26 @@ function UnitAkademikExplorer() {
       <Card className="md:col-span-2">
         <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between space-y-4 sm:space-y-0 pb-4">
           <CardTitle>Struktur Unit Akademik</CardTitle>
-          <Input
-            placeholder="Cari unit..."
-            className="max-w-xs"
-            value={search}
-            onChange={(e) => {
-              setSearch(e.target.value);
-              if (e.target.value) {
-                setExpanded(new Set(units.map((u: UnitAkademik) => u.id)));
-              } else {
-                setExpanded(new Set());
-              }
-            }}
-          />
+          <div className="flex items-center gap-2 max-w-xs w-full sm:w-auto">
+            {search.trim() !== "" && (
+              <span className="text-xs text-muted-foreground whitespace-nowrap bg-muted px-2.5 py-1 rounded-md font-medium border">
+                {filteredMatchCount} / {units.length} unit
+              </span>
+            )}
+            <Input
+              placeholder="Cari unit..."
+              className="max-w-xs"
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                if (e.target.value) {
+                  setExpanded(new Set(units.map((u: UnitAkademik) => u.id)));
+                } else {
+                  setExpanded(new Set());
+                }
+              }}
+            />
+          </div>
         </CardHeader>
         <CardContent>
           <div className="rounded-lg border bg-card p-2 min-h-[400px]">

--- a/src/routes/_authenticated/admin.akademik.index.tsx
+++ b/src/routes/_authenticated/admin.akademik.index.tsx
@@ -123,6 +123,7 @@ function UnitAkademikExplorer() {
         {children.map((u: UnitAkademik) => {
           const hasChildren = units.some((child: UnitAkademik) => child.parentId === u.id);
           const isExpanded = expanded.has(u.id);
+          const isAddingChild = !editing && form.parentId === u.id;
 
           // Filtering
           if (search && !u.nama.toLowerCase().includes(search.toLowerCase()) && !hasChildren) return null;
@@ -137,8 +138,8 @@ function UnitAkademikExplorer() {
                   className="flex h-6 w-6 cursor-pointer items-center justify-center rounded hover:bg-black/10 dark:hover:bg-white/10"
                   onClick={() => toggleExpand(u.id)}
                 >
-                  {hasChildren ? (
-                    isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />
+                  {(hasChildren || isAddingChild) ? (
+                    isExpanded ? <ChevronDown className="h-4 w-4 text-primary" /> : <ChevronRight className="h-4 w-4" />
                   ) : (
                     <div className="h-4 w-4" />
                   )}
@@ -182,7 +183,36 @@ function UnitAkademikExplorer() {
                   </Button>
                 </div>
               </div>
-              {hasChildren && isExpanded && renderTree([u.id], level + 1)}
+
+              {/* Inline Sub-unit Input Form & Children */}
+              {isExpanded && (
+                <div className="flex flex-col">
+                  {isAddingChild && (
+                    <div 
+                      className="flex items-center gap-2 rounded-md p-2 bg-primary/10 border border-primary/30 my-1 animate-in fade-in slide-in-from-top-1 duration-150"
+                      style={{ paddingLeft: `${(level + 1) * 1.5 + 0.5}rem` }}
+                    >
+                      <div className="h-4 w-4 flex items-center justify-center text-primary font-bold">↳</div>
+                      {getIcon(form.tipe)}
+                      <Input
+                        ref={inputRef}
+                        placeholder={form.tipe === "prodi" ? "Nama Program Studi..." : "Nama Kelas / Angkatan..."}
+                        className="h-8 text-sm flex-1 bg-background"
+                        value={form.nama}
+                        onChange={(e) => setForm({ ...form, nama: e.target.value })}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") save();
+                          if (e.key === "Escape") resetForm();
+                        }}
+                      />
+                      <Button size="sm" className="h-8 px-3 text-xs" onClick={save}>Simpan</Button>
+                      <Button size="sm" variant="ghost" className="h-8 px-2 text-xs" onClick={resetForm}>Batal</Button>
+                    </div>
+                  )}
+
+                  {renderTree([u.id], level + 1)}
+                </div>
+              )}
             </div>
           );
         })}

--- a/src/routes/_authenticated/admin.akademik.index.tsx
+++ b/src/routes/_authenticated/admin.akademik.index.tsx
@@ -186,11 +186,13 @@ function UnitAkademikExplorer() {
     );
   };
 
+  const parentName = form.parentId !== "none" ? units.find((u: UnitAkademik) => u.id === form.parentId)?.nama : null;
+
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
       <Card className="md:col-span-2">
         <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between space-y-4 sm:space-y-0 pb-4">
-          <CardTitle>Struktur Organisasi Akademik</CardTitle>
+          <CardTitle>Hierarki Kelas & Jurusan</CardTitle>
           <Input
             placeholder="Cari unit..."
             className="max-w-xs"
@@ -210,8 +212,8 @@ function UnitAkademikExplorer() {
             {units.length === 0 ? (
               <div className="flex h-[300px] flex-col items-center justify-center text-muted-foreground">
                 <Folder className="mb-2 h-10 w-10 opacity-20" />
-                <p>Belum ada data struktur akademik.</p>
-                <Button variant="link" onClick={() => setForm({ ...form, parentId: "none" })}>Buat Induk Pertama</Button>
+                <p>Belum ada hierarki rombongan belajar atau jurusan.</p>
+                <Button variant="link" onClick={() => setForm({ ...form, parentId: "none" })}>Buat Tingkat Pertama (Root)</Button>
               </div>
             ) : (
               renderTree(null, 0)
@@ -223,38 +225,44 @@ function UnitAkademikExplorer() {
       <div className="space-y-4">
         <Card>
           <CardHeader>
-            <CardTitle>{editing ? "Edit Unit" : "Tambah Unit Baru"}</CardTitle>
+            <CardTitle>{editing ? "Edit Rombel/Jurusan" : form.parentId !== "none" ? "Tambah Sub-Kelas" : "Tambah Kelas/Jurusan"}</CardTitle>
+            {!editing && parentName && (
+              <div className="bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 text-xs px-3 py-2 rounded-md border border-blue-200 dark:border-blue-800 mt-2 flex items-center gap-2 font-medium">
+                <div className="h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
+                Menambahkan di dalam: <strong>{parentName}</strong>
+              </div>
+            )}
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-1.5">
-              <Label>Nama Unit</Label>
+              <Label>Nama Kelompok / Rombel</Label>
               <Input
-                placeholder="Contoh: Fakultas Teknik"
+                placeholder="Contoh: Kelas X MIPA 1, atau Teknik Informatika"
                 value={form.nama}
                 onChange={(e) => setForm({ ...form, nama: e.target.value })}
               />
             </div>
             <div className="space-y-1.5">
-              <Label>Tipe Unit</Label>
+              <Label>Tingkatan</Label>
               <Select value={form.tipe} onValueChange={(val) => setForm({ ...form, tipe: val })}>
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="fakultas">Fakultas</SelectItem>
-                  <SelectItem value="prodi">Program Studi / Jurusan</SelectItem>
-                  <SelectItem value="kelas">Kelas / Paralel (A, B, C)</SelectItem>
+                  <SelectItem value="fakultas">Fakultas / Gedung Rayon</SelectItem>
+                  <SelectItem value="prodi">Jurusan / Program Studi</SelectItem>
+                  <SelectItem value="kelas">Rombel / Kelas Paralel</SelectItem>
                 </SelectContent>
               </Select>
             </div>
             <div className="space-y-1.5">
-              <Label>Induk Unit (Parent)</Label>
+              <Label>Berada di bawah (Tingkat Induk)</Label>
               <Select value={form.parentId} onValueChange={(val) => setForm({ ...form, parentId: val })}>
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="none">-- Sebagai Induk (Root) --</SelectItem>
+                  <SelectItem value="none">-- Sebagai Tingkat Utama (Root) --</SelectItem>
                   {allowedParentUnits.map((u: UnitAkademik) => (
                     <SelectItem key={u.id} value={u.id}>{u.nama} ({u.tipe})</SelectItem>
                   ))}
@@ -264,7 +272,7 @@ function UnitAkademikExplorer() {
             
             <div className="flex gap-2 pt-2">
               <Button onClick={save} className="flex-1">{editing ? "Simpan Perubahan" : "Tambahkan"}</Button>
-              {editing && <Button variant="outline" onClick={resetForm}>Batal</Button>}
+              {(editing || form.nama || form.parentId !== "none") && <Button variant="outline" onClick={resetForm}>Batal</Button>}
             </div>
           </CardContent>
         </Card>

--- a/src/routes/_authenticated/admin.akademik.index.tsx
+++ b/src/routes/_authenticated/admin.akademik.index.tsx
@@ -240,10 +240,10 @@ function UnitAkademikExplorer() {
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-      <Card className="md:col-span-2">
+      <Card className={editing ? "md:col-span-2" : "md:col-span-3"}>
         <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between space-y-4 sm:space-y-0 pb-4">
           <CardTitle>Struktur Unit Akademik</CardTitle>
-          <div className="flex items-center gap-2 max-w-xs w-full sm:w-auto">
+          <div className="flex items-center gap-2 max-w-sm w-full sm:w-auto">
             {search.trim() !== "" && (
               <span className="text-xs text-muted-foreground whitespace-nowrap bg-muted px-2.5 py-1 rounded-md font-medium border">
                 {filteredMatchCount} / {units.length} unit
@@ -262,10 +262,43 @@ function UnitAkademikExplorer() {
                 }
               }}
             />
+            <Button
+              size="sm"
+              className="gap-1 px-3 text-xs whitespace-nowrap"
+              onClick={() => {
+                setEditing(null);
+                setForm({ nama: "", tipe: "fakultas", parentId: "none" });
+                setTimeout(() => inputRef.current?.focus(), 50);
+              }}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Fakultas Utama
+            </Button>
           </div>
         </CardHeader>
         <CardContent>
           <div className="rounded-lg border bg-card p-2 min-h-[400px]">
+            {/* Inline Root Adding Form */}
+            {!editing && form.parentId === "none" && form.tipe === "fakultas" && (
+              <div className="flex items-center gap-2 rounded-md p-2 bg-primary/10 border border-primary/30 mb-3 animate-in fade-in slide-in-from-top-1 duration-150">
+                <div className="h-4 w-4 flex items-center justify-center text-primary font-bold">+</div>
+                {getIcon("fakultas")}
+                <Input
+                  ref={inputRef}
+                  placeholder="Nama Fakultas Utama Baru..."
+                  className="h-8 text-sm flex-1 bg-background"
+                  value={form.nama}
+                  onChange={(e) => setForm({ ...form, nama: e.target.value })}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") save();
+                    if (e.key === "Escape") resetForm();
+                  }}
+                />
+                <Button size="sm" className="h-8 px-3 text-xs" onClick={save}>Simpan</Button>
+                <Button size="sm" variant="ghost" className="h-8 px-2 text-xs" onClick={resetForm}>Batal</Button>
+              </div>
+            )}
+
             {units.length === 0 ? (
               <div className="flex h-[300px] flex-col items-center justify-center text-muted-foreground">
                 <Folder className="mb-2 h-10 w-10 opacity-20" />
@@ -279,11 +312,12 @@ function UnitAkademikExplorer() {
         </CardContent>
       </Card>
 
-      <div className="space-y-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>{editing ? "Edit Unit Akademik" : "Tambah Unit Akademik"}</CardTitle>
-          </CardHeader>
+      {editing && (
+        <div className="space-y-4 animate-in fade-in slide-in-from-right-2 duration-200">
+          <Card>
+            <CardHeader>
+              <CardTitle>Edit Unit Akademik</CardTitle>
+            </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-1.5">
               <Label>Nama Unit Akademik</Label>
@@ -323,12 +357,13 @@ function UnitAkademikExplorer() {
             </div>
             
             <div className="flex gap-2 pt-2">
-              <Button onClick={save} className="flex-1">{editing ? "Simpan Perubahan" : "Tambah Unit"}</Button>
-              {(editing || form.nama || form.parentId !== "none") && <Button variant="outline" onClick={resetForm}>Reset</Button>}
+              <Button onClick={save} className="flex-1">Simpan Perubahan</Button>
+              <Button variant="outline" onClick={resetForm}>Batal</Button>
             </div>
           </CardContent>
         </Card>
       </div>
+      )}
     </div>
   );
 }

--- a/src/routes/_authenticated/admin.akademik.index.tsx
+++ b/src/routes/_authenticated/admin.akademik.index.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { createFileRoute } from "@tanstack/react-router";
-import { useState, useRef } from "react";
-import { unitAkademikRepo } from "@/lib/cbt/repos";
+import { useState, useRef, useEffect } from "react";
+import { unitAkademikRepo, hydrateRepos } from "@/lib/cbt/repos";
 import { mutateUnitAkademikServer } from "@/lib/server/akademik/functions";
 import type { UnitAkademik } from "@/lib/cbt/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -11,6 +10,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Plus, Edit2, Trash2, ChevronRight, ChevronDown, Folder, Building2, Library, Users } from "lucide-react";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/_authenticated/admin/akademik/")({
   component: UnitAkademikExplorer,
@@ -31,8 +31,9 @@ function getDescendantIds(targetId: string, units: UnitAkademik[]): Set<string> 
 }
 
 function highlightText(text: string, query: string) {
-  if (!query.trim()) return text;
-  const parts = text.split(new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi"));
+  const safeText = text || "";
+  if (!query.trim()) return safeText;
+  const parts = safeText.split(new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi"));
   return parts.map((part, i) =>
     part.toLowerCase() === query.toLowerCase() ? (
       <mark key={i} className="bg-amber-200 dark:bg-amber-900/80 dark:text-amber-100 font-semibold px-0.5 rounded">
@@ -48,14 +49,28 @@ function UnitAkademikExplorer() {
   const [units, setUnits] = useState<UnitAkademik[]>(unitAkademikRepo.all());
   const [search, setSearch] = useState("");
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [selectedUnitId, setSelectedUnitId] = useState<string | null>(null);
+  const [isAddingRoot, setIsAddingRoot] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    hydrateRepos().then(() => {
+      if (isMounted) {
+        setUnits([...unitAkademikRepo.all()]);
+      }
+    }).catch(() => undefined);
+    return () => { isMounted = false; };
+  }, []);
+
+  const selectedUnit = selectedUnitId ? units.find((u: UnitAkademik) => u.id === selectedUnitId) || null : null;
 
   // Form State
   const [editing, setEditing] = useState<UnitAkademik | null>(null);
   const [form, setForm] = useState({ nama: "", tipe: "fakultas", parentId: "none" });
 
   const filteredMatchCount = search.trim()
-    ? units.filter((u: UnitAkademik) => u.nama.toLowerCase().includes(search.toLowerCase())).length
+    ? units.filter((u: UnitAkademik) => (u.nama || "").toLowerCase().includes(search.toLowerCase())).length
     : units.length;
 
   const toggleExpand = (id: string) => {
@@ -78,6 +93,7 @@ function UnitAkademikExplorer() {
 
   const resetForm = () => {
     setEditing(null);
+    setIsAddingRoot(false);
     setForm({ nama: "", tipe: "fakultas", parentId: "none" });
   };
 
@@ -132,7 +148,7 @@ function UnitAkademikExplorer() {
   const renderTree = (parentIds: string[] | null, level: number = 0) => {
     const children = units
       .filter((u: UnitAkademik) => (parentIds === null ? !u.parentId : parentIds.includes(u.parentId || "")))
-      .sort((a: UnitAkademik, b: UnitAkademik) => a.nama.localeCompare(b.nama));
+      .sort((a: UnitAkademik, b: UnitAkademik) => (a.nama || "").localeCompare(b.nama || ""));
 
     if (children.length === 0) return null;
 
@@ -144,17 +160,27 @@ function UnitAkademikExplorer() {
           const isAddingChild = !editing && form.parentId === u.id;
 
           // Filtering
-          if (search && !u.nama.toLowerCase().includes(search.toLowerCase()) && !hasChildren) return null;
+          if (search && !(u.nama || "").toLowerCase().includes(search.toLowerCase()) && !hasChildren) return null;
 
           return (
             <div key={u.id}>
               <div
-                className={`flex items-center gap-2 rounded-md p-2 transition-colors hover:bg-accent/50 ${editing?.id === u.id ? "bg-accent" : ""}`}
+                className={`flex items-center gap-2 rounded-md p-2 transition-colors cursor-pointer ${
+                  selectedUnit?.id === u.id
+                    ? "bg-primary/10 border-l-2 border-primary font-semibold text-foreground"
+                    : editing?.id === u.id
+                    ? "bg-accent"
+                    : "hover:bg-accent/50"
+                }`}
                 style={{ paddingLeft: `${level * 1.5 + 0.5}rem` }}
+                onClick={() => setSelectedUnitId(prev => prev === u.id ? null : u.id)}
               >
                 <div
                   className="flex h-6 w-6 cursor-pointer items-center justify-center rounded hover:bg-black/10 dark:hover:bg-white/10"
-                  onClick={() => toggleExpand(u.id)}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleExpand(u.id);
+                  }}
                 >
                   {(hasChildren || isAddingChild) ? (
                     isExpanded ? <ChevronDown className="h-4 w-4 text-primary" /> : <ChevronRight className="h-4 w-4" />
@@ -166,20 +192,24 @@ function UnitAkademikExplorer() {
                 <span className="flex-1 text-sm font-medium">{highlightText(u.nama, search)}</span>
                 <span className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground uppercase">{u.tipe}</span>
                 
-                <div className="flex items-center gap-1 opacity-50 hover:opacity-100">
+                <div className="flex items-center gap-1 opacity-50 hover:opacity-100" onClick={(e) => e.stopPropagation()}>
                   <Button
                     variant="ghost"
                     size="icon"
                     className="h-7 w-7"
                     onClick={() => {
                       setEditing(u);
+                      setSelectedUnitId(u.id);
                       setForm({ nama: u.nama, tipe: u.tipe, parentId: u.parentId || "none" });
                       setTimeout(() => inputRef.current?.focus(), 50);
                     }}
                   >
                     <Edit2 className="h-3.5 w-3.5" />
                   </Button>
-                  <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:bg-destructive/10" onClick={() => remove(u.id)}>
+                  <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:bg-destructive/10" onClick={() => {
+                    remove(u.id);
+                    if (selectedUnitId === u.id) setSelectedUnitId(null);
+                  }}>
                     <Trash2 className="h-3.5 w-3.5" />
                   </Button>
                   <Button 
@@ -189,6 +219,7 @@ function UnitAkademikExplorer() {
                     title="Tambah Sub-Unit"
                     onClick={() => {
                       setEditing(null);
+                      setSelectedUnitId(u.id);
                       const nextType = u.tipe === "fakultas" ? "prodi" : "kelas";
                       setForm({ nama: "", tipe: nextType, parentId: u.id });
                       const next = new Set(expanded);
@@ -239,10 +270,11 @@ function UnitAkademikExplorer() {
   };
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-      <Card className={editing ? "md:col-span-2" : "md:col-span-3"}>
+    <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
+      {/* Left Tree Explorer (7 Cols) */}
+      <Card className="lg:col-span-7">
         <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between space-y-4 sm:space-y-0 pb-4">
-          <CardTitle>Struktur Unit Akademik</CardTitle>
+          <CardTitle className="text-base font-bold">Struktur Unit Akademik</CardTitle>
           <div className="flex items-center gap-2 max-w-sm w-full sm:w-auto">
             {search.trim() !== "" && (
               <span className="text-xs text-muted-foreground whitespace-nowrap bg-muted px-2.5 py-1 rounded-md font-medium border">
@@ -251,7 +283,7 @@ function UnitAkademikExplorer() {
             )}
             <Input
               placeholder="Cari unit..."
-              className="max-w-xs"
+              className="max-w-xs h-8 text-xs"
               value={search}
               onChange={(e) => {
                 setSearch(e.target.value);
@@ -264,28 +296,30 @@ function UnitAkademikExplorer() {
             />
             <Button
               size="sm"
-              className="gap-1 px-3 text-xs whitespace-nowrap"
+              className="gap-1 px-2.5 h-8 text-xs whitespace-nowrap"
               onClick={() => {
                 setEditing(null);
+                setSelectedUnitId(null);
+                setIsAddingRoot(true);
                 setForm({ nama: "", tipe: "fakultas", parentId: "none" });
                 setTimeout(() => inputRef.current?.focus(), 50);
               }}
             >
               <Plus className="h-3.5 w-3.5" />
-              Fakultas Utama
+              Tambah Fakultas
             </Button>
           </div>
         </CardHeader>
         <CardContent>
-          <div className="rounded-lg border bg-card p-2 min-h-[400px]">
+          <div className="rounded-lg border bg-card p-2 min-h-[420px]">
             {/* Inline Root Adding Form */}
-            {!editing && form.parentId === "none" && form.tipe === "fakultas" && (
+            {!editing && isAddingRoot && (
               <div className="flex items-center gap-2 rounded-md p-2 bg-primary/10 border border-primary/30 mb-3 animate-in fade-in slide-in-from-top-1 duration-150">
                 <div className="h-4 w-4 flex items-center justify-center text-primary font-bold">+</div>
                 {getIcon("fakultas")}
                 <Input
                   ref={inputRef}
-                  placeholder="Nama Fakultas Utama Baru..."
+                  placeholder="Nama Fakultas Baru..."
                   className="h-8 text-sm flex-1 bg-background"
                   value={form.nama}
                   onChange={(e) => setForm({ ...form, nama: e.target.value })}
@@ -312,58 +346,197 @@ function UnitAkademikExplorer() {
         </CardContent>
       </Card>
 
-      {editing && (
-        <div className="space-y-4 animate-in fade-in slide-in-from-right-2 duration-200">
-          <Card>
-            <CardHeader>
-              <CardTitle>Edit Unit Akademik</CardTitle>
+      {/* Right Column (5 Cols): Edit Form OR Detail Panel OR Guidance */}
+      <div className="lg:col-span-5 space-y-4">
+        {editing ? (
+          <Card className="border-primary/30 shadow-xs animate-in fade-in slide-in-from-right-2 duration-200">
+            <CardHeader className="pb-3 border-b">
+              <CardTitle className="text-base font-bold">Edit Unit Akademik</CardTitle>
             </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-1.5">
-              <Label>Nama Unit Akademik</Label>
-              <Input
-                ref={inputRef}
-                placeholder="Contoh: Fakultas Ilmu Komputer / S1 Teknik Informatika"
-                value={form.nama}
-                onChange={(e) => setForm({ ...form, nama: e.target.value })}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label>Tipe Unit</Label>
-              <Select value={form.tipe} onValueChange={(val) => setForm({ ...form, tipe: val })}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="fakultas">Fakultas</SelectItem>
-                  <SelectItem value="prodi">Program Studi / Jurusan</SelectItem>
-                  <SelectItem value="kelas">Kelas / Angkatan</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-1.5">
-              <Label>Unit Induk (Parent)</Label>
-              <Select value={form.parentId} onValueChange={(val) => setForm({ ...form, parentId: val })}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">-- Tanpa Induk (Fakultas / Utama) --</SelectItem>
-                  {allowedParentUnits.map((u: UnitAkademik) => (
-                    <SelectItem key={u.id} value={u.id}>{u.nama} ({u.tipe})</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            
-            <div className="flex gap-2 pt-2">
-              <Button onClick={save} className="flex-1">Simpan Perubahan</Button>
-              <Button variant="outline" onClick={resetForm}>Batal</Button>
-            </div>
-          </CardContent>
-        </Card>
+            <CardContent className="space-y-4 pt-4">
+              <div className="space-y-1.5">
+                <Label className="text-xs">Nama Unit Akademik</Label>
+                <Input
+                  ref={inputRef}
+                  placeholder="Contoh: Fakultas Ilmu Komputer / S1 Teknik Informatika"
+                  value={form.nama}
+                  onChange={(e) => setForm({ ...form, nama: e.target.value })}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">Tipe Unit</Label>
+                <Select value={form.tipe} onValueChange={(val) => setForm({ ...form, tipe: val })}>
+                  <SelectTrigger className="h-9 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="fakultas">Fakultas</SelectItem>
+                    <SelectItem value="prodi">Program Studi / Jurusan</SelectItem>
+                    <SelectItem value="kelas">Kelas / Angkatan</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">Unit Induk (Parent)</Label>
+                <Select value={form.parentId} onValueChange={(val) => setForm({ ...form, parentId: val })}>
+                  <SelectTrigger className="h-9 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">-- Tanpa Induk (Fakultas / Utama) --</SelectItem>
+                    {allowedParentUnits.map((u: UnitAkademik) => (
+                      <SelectItem key={u.id} value={u.id}>{u.nama} ({u.tipe})</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              
+              <div className="flex gap-2 pt-2">
+                <Button size="sm" onClick={save} className="flex-1 text-xs">Simpan Perubahan</Button>
+                <Button size="sm" variant="outline" onClick={resetForm} className="text-xs">Batal</Button>
+              </div>
+            </CardContent>
+          </Card>
+        ) : selectedUnit ? (
+          <Card className="border shadow-xs animate-in fade-in duration-200">
+            <CardHeader className="pb-3 border-b">
+              {/* Visual Breadcrumb Path */}
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-2 overflow-x-auto pb-1 scrollbar-none">
+                {(() => {
+                  const path: UnitAkademik[] = [selectedUnit];
+                  let curr = selectedUnit;
+                  const visited = new Set<string>([selectedUnit.id]);
+                  while (curr.parentId) {
+                    const p = units.find(x => x.id === curr.parentId);
+                    if (p && !visited.has(p.id)) {
+                      visited.add(p.id);
+                      path.unshift(p);
+                      curr = p;
+                    } else break;
+                  }
+                  return path.map((item, idx) => (
+                    <div key={item.id} className="flex items-center gap-1 shrink-0">
+                      {idx > 0 && <ChevronRight className="h-3 w-3 text-muted-foreground/50" />}
+                      <span className={cn("inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px]", idx === path.length - 1 ? "bg-primary/10 text-primary font-semibold" : "bg-muted")}>
+                        {getIcon(item.tipe)}
+                        {item.nama}
+                      </span>
+                    </div>
+                  ));
+                })()}
+              </div>
+
+              <div className="flex items-center gap-3 pt-1">
+                <div className="p-2.5 rounded-xl bg-primary/10 border border-primary/20">
+                  {getIcon(selectedUnit.tipe)}
+                </div>
+                <div>
+                  <CardTitle className="text-base font-bold">{selectedUnit.nama}</CardTitle>
+                  <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold">
+                    {selectedUnit.tipe}
+                  </span>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4 pt-4">
+              {/* Visual Sub-units List */}
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-bold text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
+                    <Folder className="h-3.5 w-3.5 text-primary" />
+                    Sub-Unit Terdaftar
+                  </span>
+                  <span className="text-[11px] text-primary bg-primary/10 px-2 py-0.5 rounded-full font-bold">
+                    {units.filter(x => x.parentId === selectedUnit.id).length} Sub-unit
+                  </span>
+                </div>
+
+                <div className="rounded-xl border bg-muted/20 p-2 max-h-52 overflow-y-auto space-y-1.5 scrollbar-thin">
+                  {units.filter(x => x.parentId === selectedUnit.id).length === 0 ? (
+                    <div className="py-6 text-center space-y-1">
+                      <Folder className="h-6 w-6 text-muted-foreground/30 mx-auto" />
+                      <p className="text-xs text-muted-foreground italic">
+                        Belum ada sub-unit di bawah {selectedUnit.nama}.
+                      </p>
+                    </div>
+                  ) : (
+                    units
+                      .filter(x => x.parentId === selectedUnit.id)
+                      .map(child => (
+                        <div key={child.id} className="flex items-center gap-2.5 p-2 rounded-lg bg-card border text-xs shadow-2xs hover:border-primary/40 transition-colors">
+                          <div className="p-1.5 rounded-md bg-muted">
+                            {getIcon(child.tipe)}
+                          </div>
+                          <span className="font-semibold text-foreground flex-1">{child.nama}</span>
+                          <span className="text-[10px] text-muted-foreground uppercase bg-muted px-2 py-0.5 rounded font-medium">
+                            {child.tipe}
+                          </span>
+                        </div>
+                      ))
+                  )}
+                </div>
+              </div>
+
+              {/* Direct Actions */}
+              <div className="space-y-2 pt-2 border-t">
+                <Button
+                  size="sm"
+                  className="w-full gap-2 text-xs"
+                  onClick={() => {
+                    setEditing(null);
+                    const nextType = selectedUnit.tipe === "fakultas" ? "prodi" : "kelas";
+                    setForm({ nama: "", tipe: nextType, parentId: selectedUnit.id });
+                    const next = new Set(expanded);
+                    next.add(selectedUnit.id);
+                    setExpanded(next);
+                    setTimeout(() => inputRef.current?.focus(), 50);
+                  }}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Tambah Sub-Unit di Bawah Ini
+                </Button>
+                
+                <div className="grid grid-cols-2 gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="gap-1.5 text-xs"
+                    onClick={() => {
+                      setEditing(selectedUnit);
+                      setForm({ nama: selectedUnit.nama, tipe: selectedUnit.tipe, parentId: selectedUnit.parentId || "none" });
+                      setTimeout(() => inputRef.current?.focus(), 50);
+                    }}
+                  >
+                    <Edit2 className="h-3.5 w-3.5" />
+                    Edit Unit
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    className="gap-1.5 text-xs"
+                    onClick={() => {
+                      remove(selectedUnit.id);
+                      setSelectedUnitId(null);
+                    }}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                    Hapus Unit
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          /* Clean Simple Placeholder (When nothing selected) */
+          <Card className="min-h-[280px] border-dashed bg-muted/10 flex flex-col items-center justify-center text-center p-6 space-y-2">
+            <Building2 className="h-8 w-8 text-muted-foreground/30 mb-1" />
+            <h4 className="text-xs font-semibold text-muted-foreground">Detail Unit Akademik</h4>
+            <p className="text-[11px] text-muted-foreground/70 max-w-xs leading-relaxed">
+              Pilih salah satu Fakultas, Prodi, atau Kelas pada pohon hirarki di sebelah kiri untuk melihat rincian visual dan opsi aksi cepat.
+            </p>
+          </Card>
+        )}
       </div>
-      )}
     </div>
   );
 }

--- a/src/routes/_authenticated/admin.akademik.tsx
+++ b/src/routes/_authenticated/admin.akademik.tsx
@@ -53,57 +53,35 @@ function AkademikLayout() {
         </Alert>
       </div>
 
-      <div className="flex flex-col lg:flex-row gap-8 items-start">
-        
-        {/* Sidebar Navigation */}
-        <aside className="w-full lg:w-64 shrink-0 space-y-6">
-          {TREE_MENU.map((group, idx) => (
-            <div key={idx} className="space-y-2">
-              <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground px-2">
-                {group.section}
-              </h4>
-              <nav className="flex flex-col space-y-1">
-                {group.items.map((item) => {
-                  const active = item.to === "/admin/akademik"
-                    ? (pathname === "/admin/akademik" || pathname === "/admin/akademik/")
-                    : pathname.startsWith(item.to);
-                  const Icon = item.icon;
-                  return (
-                    <Link
-                      key={item.to}
-                      to={item.to}
-                      className={cn(
-                        "group flex items-center justify-between px-3 py-2 text-sm font-medium rounded-md transition-colors",
-                        active
-                          ? "bg-accent text-accent-foreground font-semibold"
-                          : "text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-                      )}
-                      style={{ marginLeft: `${item.indent * 12}px` }}
-                    >
-                      <div className="flex items-center gap-3">
-                        <Icon className={cn(
-                          "h-4 w-4 shrink-0", 
-                          active ? "text-foreground" : "text-muted-foreground group-hover:text-foreground"
-                        )} />
-                        {item.label}
-                      </div>
-                      {active && <ChevronRight className="h-4 w-4 opacity-50" />}
-                    </Link>
-                  );
-                })}
-              </nav>
-            </div>
-          ))}
-        </aside>
-
-        {/* Content Outlet */}
-        <main className="flex-1 w-full min-h-[500px]">
-          <div className="py-1">
-            <Outlet />
-          </div>
-        </main>
-
+      {/* Top Sub-Navigation Tabs */}
+      <div className="flex flex-wrap items-center gap-2 border-b pb-3">
+        {TREE_MENU.flatMap(group => group.items).map((item) => {
+          const active = item.to === "/admin/akademik"
+            ? (pathname === "/admin/akademik" || pathname === "/admin/akademik/")
+            : pathname.startsWith(item.to);
+          const Icon = item.icon;
+          return (
+            <Link
+              key={item.to}
+              to={item.to}
+              className={cn(
+                "inline-flex items-center gap-2 px-3.5 py-2 text-sm font-medium rounded-md transition-all",
+                active
+                  ? "bg-primary text-primary-foreground font-semibold shadow-sm"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              )}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              {item.label}
+            </Link>
+          );
+        })}
       </div>
+
+      {/* Content Outlet (Full Width) */}
+      <main className="w-full min-h-[500px]">
+        <Outlet />
+      </main>
     </div>
   );
 }

--- a/src/routes/_authenticated/admin.akademik.tsx
+++ b/src/routes/_authenticated/admin.akademik.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute, Link, Outlet, useLocation } from "@tanstack/react-router";
+import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { Network, Calendar, Clock, BookOpen, ChevronRight, AlertTriangle } from "lucide-react";
+import { Network, Calendar, Clock, BookOpen, ChevronRight, AlertTriangle, X } from "lucide-react";
 import { AdminPageHeader } from "@/components/cbt/AdminPage";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 
 export const Route = createFileRoute("/_authenticated/admin/akademik")({
   component: AkademikLayout,
@@ -32,6 +34,7 @@ const TREE_MENU = [
 
 function AkademikLayout() {
   const { pathname } = useLocation();
+  const [showAlert, setShowAlert] = useState(true);
 
   return (
     <div className="w-full space-y-6">
@@ -43,45 +46,76 @@ function AkademikLayout() {
           description="Kelola data induk institusi. Konfigurasi di sini akan menjadi fondasi bagi pengelolaan mahasiswa, dosen, dan mata kuliah."
         />
 
-        {/* Informasi Penekanan (Alert) */}
-        <Alert variant="destructive" className="bg-amber-500/10 text-amber-900 dark:text-amber-300 border-amber-500/30">
-          <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-          <AlertTitle className="font-semibold text-amber-800 dark:text-amber-300">Perhatian: Modifikasi Struktur Induk</AlertTitle>
-          <AlertDescription className="text-xs text-amber-700 dark:text-amber-400/90 leading-relaxed mt-1">
-            Penghapusan atau perubahan mendasar pada <strong>Fakultas atau Jurusan</strong> dapat menyebabkan data mahasiswa dan modul bank soal yang terkait menjadi tidak sinkron (<em>orphaned</em>). Pastikan Anda hanya mengubah data ini jika benar-benar diperlukan.
-          </AlertDescription>
-        </Alert>
-      </div>
-
-      {/* Top Sub-Navigation Tabs */}
-      <div className="flex flex-wrap items-center gap-2 border-b pb-3">
-        {TREE_MENU.flatMap(group => group.items).map((item) => {
-          const active = item.to === "/admin/akademik"
-            ? (pathname === "/admin/akademik" || pathname === "/admin/akademik/")
-            : pathname.startsWith(item.to);
-          const Icon = item.icon;
-          return (
-            <Link
-              key={item.to}
-              to={item.to}
-              className={cn(
-                "inline-flex items-center gap-2 px-3.5 py-2 text-sm font-medium rounded-md transition-all",
-                active
-                  ? "bg-primary text-primary-foreground font-semibold shadow-sm"
-                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
-              )}
+        {/* Informasi Penekanan (Alert) dengan Tombol Tutup */}
+        {showAlert && (
+          <Alert variant="destructive" className="relative bg-amber-500/10 text-amber-900 dark:text-amber-300 border-amber-500/30 pr-10">
+            <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+            <AlertTitle className="font-semibold text-amber-800 dark:text-amber-300">Perhatian: Modifikasi Struktur Induk</AlertTitle>
+            <AlertDescription className="text-xs text-amber-700 dark:text-amber-400/90 leading-relaxed mt-1">
+              Penghapusan atau perubahan mendasar pada <strong>Fakultas atau Jurusan</strong> dapat menyebabkan data mahasiswa dan modul bank soal yang terkait menjadi tidak sinkron (<em>orphaned</em>). Pastikan Anda hanya mengubah data ini jika benar-benar diperlukan.
+            </AlertDescription>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute top-2 right-2 h-6 w-6 text-amber-800 dark:text-amber-300 hover:bg-amber-500/20"
+              onClick={() => setShowAlert(false)}
+              title="Tutup perhatian"
             >
-              <Icon className="h-4 w-4 shrink-0" />
-              {item.label}
-            </Link>
-          );
-        })}
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          </Alert>
+        )}
       </div>
 
-      {/* Content Outlet (Full Width) */}
-      <main className="w-full min-h-[500px]">
-        <Outlet />
-      </main>
+      {/* Main Container with Compact Sub-Sidebar */}
+      <div className="flex flex-col lg:flex-row gap-6 items-start">
+        
+        {/* Compact Sub-Sidebar Navigation */}
+        <aside className="w-full lg:w-56 shrink-0 bg-card/60 backdrop-blur-sm p-3 rounded-xl border space-y-5">
+          {TREE_MENU.map((group, idx) => (
+            <div key={idx} className="space-y-1.5">
+              <h4 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground/80 px-2.5">
+                {group.section}
+              </h4>
+              <nav className="flex flex-col space-y-0.5">
+                {group.items.map((item) => {
+                  const active = item.to === "/admin/akademik"
+                    ? (pathname === "/admin/akademik" || pathname === "/admin/akademik/")
+                    : pathname.startsWith(item.to);
+                  const Icon = item.icon;
+                  return (
+                    <Link
+                      key={item.to}
+                      to={item.to}
+                      className={cn(
+                        "group flex items-center justify-between px-2.5 py-1.5 text-xs font-medium rounded-lg transition-all",
+                        active
+                          ? "bg-primary text-primary-foreground font-semibold shadow-xs"
+                          : "text-muted-foreground hover:bg-muted/70 hover:text-foreground"
+                      )}
+                    >
+                      <div className="flex items-center gap-2.5">
+                        <Icon className={cn(
+                          "h-3.5 w-3.5 shrink-0",
+                          active ? "text-primary-foreground" : "text-muted-foreground group-hover:text-foreground"
+                        )} />
+                        {item.label}
+                      </div>
+                      {active && <ChevronRight className="h-3.5 w-3.5 opacity-60" />}
+                    </Link>
+                  );
+                })}
+              </nav>
+            </div>
+          ))}
+        </aside>
+
+        {/* Content Outlet */}
+        <main className="flex-1 w-full min-h-[500px]">
+          <Outlet />
+        </main>
+
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Summary of Changes

1. **Sub-Sidebar Restructure**:
   - Restored compact left sub-sidebar (`w-56`) with `TREE_MENU` sections (*Struktur Institusi*, *Waktu Perkuliahan*, *Kurikulum*).
2. **Campus Terminology & Direct Input Row**:
   - Replaced generic/school copywriting with campus-appropriate terms (*Fakultas*, *Program Studi*, *Kelas*).
   - Added direct inline input row (`↳`) under parent node with auto-focus.
   - Renamed header button to **"Tambah Fakultas"** and hid initial root form by default.
3. **Reactive Icon-Driven Detail Panel**:
   - Swapped stale object references for `selectedUnitId` string state.
   - Rendered visual breadcrumb path (`Fakultas > Prodi > Kelas`) with icons.
   - Added `hydrateRepos()` on mount and null safety guards to prevent unhandled React exceptions.
4. **Close Button on Alert Box**:
   - Added top-right `X` close icon button to "Perhatian: Modifikasi Struktur Induk" alert panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a two-column academic structure management layout with a detailed selection panel.
  * Added search result counts, match highlighting, and automatic expansion of matching tree nodes.
  * Added inline forms for creating sub-units, with Save, Cancel, Enter, and Escape controls.
  * Added breadcrumbs, sub-unit listings, and direct actions for selected units.
  * Added a dismissible warning about structural changes.

* **Style**
  * Refined sidebar navigation, spacing, icons, and active states.
  * Improved the academic structure explorer’s responsive layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->