### PR TITLE
UI: Restore Neobrutalism for Pengaturan and Admin Layout

### DIFF
--- a/src/routes/_authenticated/admin.pengaturan.tsx
+++ b/src/routes/_authenticated/admin.pengaturan.tsx
@@ -63,7 +63,7 @@ function PengaturanPage() {
   }
 
   return (
-    <AdminPage className="">
+    <AdminPage className="neo-ready">
       <AdminPageHeader
         title="Pengaturan Aplikasi"
         description="Konfigurasi institusi, keamanan, browser ujian, dan branding CBT."

--- a/src/routes/_authenticated/admin.tsx
+++ b/src/routes/_authenticated/admin.tsx
@@ -8,6 +8,7 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { useAuthStore } from "@/lib/cbt/auth-store";
+import { useThemeStore } from "@/lib/cbt/theme-store";
 import { configRepo, hydrateRepos } from "@/lib/cbt/repos";
 import { type AppConfig, type NavKey, type Role } from "@/lib/cbt/types";
 import { Button } from "@/components/ui/button";
@@ -176,25 +177,26 @@ function AdminLayout() {
   const cfg = configRepo.get();
   const appName = cfg.appName;
 
-  const [theme, setTheme] = useState("light");
+  const [colorMode, setColorMode] = useState("light");
+  const { theme: uiTheme } = useThemeStore();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem("theme");
     if (stored === "dark" || stored === "light") {
-      setTheme(stored);
+      setColorMode(stored);
       if (stored === "dark") document.documentElement.classList.add("dark");
       else document.documentElement.classList.remove("dark");
     } else {
       const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-      setTheme(prefersDark ? "dark" : "light");
+      setColorMode(prefersDark ? "dark" : "light");
       if (prefersDark) document.documentElement.classList.add("dark");
     }
   }, []);
 
   const toggleTheme = () => {
-    const next = theme === "light" ? "dark" : "light";
-    setTheme(next);
+    const next = colorMode === "light" ? "dark" : "light";
+    setColorMode(next);
     localStorage.setItem("theme", next);
     if (next === "dark") document.documentElement.classList.add("dark");
     else document.documentElement.classList.remove("dark");
@@ -205,7 +207,7 @@ function AdminLayout() {
   }, [pathname]);
 
   return (
-    <div className="min-h-screen bg-slate-50/50 dark:bg-slate-950 text-slate-900 dark:text-slate-100">
+    <div className={cn("min-h-screen bg-slate-50/50 dark:bg-slate-950 text-slate-900 dark:text-slate-100", uiTheme === "neobrutalism" && "neo-ready")}>
       <div className="flex">
         
         {/* Mobile Menu Overlay */}
@@ -218,10 +220,10 @@ function AdminLayout() {
 
         {/* Sidebar */}
         <aside className={cn(
-            "w-64 shrink-0 border-r border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 lg:block transition-transform duration-200 z-50 lg:sticky lg:top-0 lg:h-screen lg:overflow-y-auto scrollbar-thin",
-            mobileMenuOpen ? "fixed inset-y-0 left-0 h-screen overflow-y-auto shadow-xl" : "hidden"
+            uiTheme === "neobrutalism" ? "w-72 shrink-0 border-r-[length:var(--neo-border-width)] border-r-[color:var(--neo-border-color)] bg-white text-[color:var(--neo-text)] lg:block transition-transform duration-300 z-50 lg:sticky lg:top-0 lg:h-screen lg:overflow-y-auto scrollbar-thin" : "w-64 shrink-0 border-r border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 lg:block transition-transform duration-200 z-50 lg:sticky lg:top-0 lg:h-screen lg:overflow-y-auto scrollbar-thin",
+            mobileMenuOpen ? cn("fixed inset-y-0 left-0 h-screen overflow-y-auto", uiTheme === "neobrutalism" ? "shadow-[var(--neo-shadow)]" : "shadow-xl") : "hidden"
           )}>
-            <div className="flex h-16 items-center justify-between border-b border-slate-200 dark:border-slate-800 px-5">
+            <div className={cn("flex h-16 items-center justify-between px-5", uiTheme === "neobrutalism" ? "border-b-[length:var(--neo-border-width)] border-b-[color:var(--neo-border-color)] font-black uppercase tracking-wider text-xl bg-white" : "border-b border-slate-200 dark:border-slate-800")}>
               <div className="flex items-center gap-3">
                 {cfg.appLogo ? (
                   <img src={cfg.appLogo} alt="Logo" className="h-7 w-auto object-contain" />
@@ -230,7 +232,7 @@ function AdminLayout() {
                     Z
                   </span>
                 )}
-                <span className="font-bold text-slate-900 dark:text-slate-100 text-base tracking-tight truncate">{appName}</span>
+                <span className={cn("truncate", uiTheme === "neobrutalism" ? "font-black text-black text-xl tracking-wider" : "font-bold text-slate-900 dark:text-slate-100 text-base tracking-tight")}>{appName}</span>
               </div>
               {mobileMenuOpen && (
                 <Button variant="ghost" size="icon" title="Tutup menu navigasi" aria-label="Tutup menu navigasi" className="lg:hidden h-8 w-8 text-slate-500 hover:text-slate-900" onClick={() => setMobileMenuOpen(false)}>
@@ -248,7 +250,7 @@ function AdminLayout() {
 
                 return (
                   <div key={group.label} className="flex flex-col gap-1.5">
-                    <h3 className="px-3 text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+                    <h3 className={cn("px-3 text-[11px] uppercase tracking-wider", uiTheme === "neobrutalism" ? "w-full text-center py-2 font-black text-[color:var(--neo-text)] bg-[color:var(--neo-bg)] border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] shadow-[var(--neo-shadow)]" : "font-semibold text-slate-400 dark:text-slate-500")}>
                       {group.label}
                     </h3>
                     <div className="flex flex-col gap-1">
@@ -260,14 +262,14 @@ function AdminLayout() {
                             to={n.to as never}
                             activeOptions={{ exact: n.exact }}
                             activeProps={{
-                              className: "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900 font-semibold shadow-sm"
+                              className: uiTheme === "neobrutalism" ? "bg-[color:var(--neo-accent)] text-[color:var(--neo-text)] translate-x-[4px] translate-y-[4px] shadow-[var(--neo-shadow)]" : "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900 font-semibold shadow-sm"
                             }}
                             inactiveProps={{
-                              className: "text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-100"
+                              className: uiTheme === "neobrutalism" ? "bg-white text-[color:var(--neo-text)] shadow-[var(--neo-shadow)] hover:bg-[color:var(--neo-bg)] hover:text-[color:var(--neo-text)] hover:translate-x-[4px] hover:translate-y-[4px] hover:shadow-[var(--neo-shadow)]" : "text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-100"
                             }}
-                            className="flex items-center gap-3 px-3 py-2 text-xs md:text-sm rounded-lg transition-colors duration-150"
+                            className={cn("flex items-center gap-3 transition-colors duration-150", uiTheme === "neobrutalism" ? "border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] px-4 py-3 text-xs md:text-sm font-black uppercase tracking-wider transition-all duration-100 ease-in-out rounded-[var(--neo-radius)]" : "px-3 py-2 text-xs md:text-sm rounded-lg")}
                           >
-                            <Icon className="h-4 w-4 shrink-0" />
+                            <Icon className={cn("shrink-0", uiTheme === "neobrutalism" ? "h-5 w-5 stroke-[2.5]" : "h-4 w-4")} />
                             <span className="leading-snug">{n.label}</span>
                           </Link>
                         );
@@ -281,45 +283,51 @@ function AdminLayout() {
 
         <div className="flex min-h-screen flex-1 flex-col min-w-0">
 
-          <header className="flex h-16 items-center justify-between border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 backdrop-blur-md px-4 lg:px-6 sticky top-0 z-30">
+          <header className={cn("flex h-16 items-center justify-between sticky top-0 z-30 px-4 lg:px-6", uiTheme === "neobrutalism" ? "border-b-[length:var(--neo-border-width)] border-b-[color:var(--neo-border-color)] bg-white" : "border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 backdrop-blur-md")}>
             <div className="flex items-center gap-4">
               <Button
                 variant="ghost"
                 size="icon"
                 title="Buka menu navigasi"
                 aria-label="Buka menu navigasi"
-                className="lg:hidden h-9 w-9 text-slate-500 hover:text-slate-900"
+                className={cn("lg:hidden", uiTheme === "neobrutalism" ? "h-10 w-10 border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] bg-[color:var(--neo-bg)] hover:bg-[color:var(--neo-accent)] shadow-[var(--neo-shadow)] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[var(--neo-shadow)] rounded-[var(--neo-radius)]" : "h-9 w-9 text-slate-500 hover:text-slate-900")}
                 onClick={() => setMobileMenuOpen(true)}
               >
                 <Menu className="h-5 w-5" />
               </Button>
-              <div className="text-sm hidden sm:flex items-center gap-3">
-                <span className="font-semibold text-slate-900 dark:text-slate-100 text-sm">{user.namaLengkap}</span>
-                <Badge variant="outline" className="font-medium text-[11px] uppercase border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 text-slate-600 dark:text-slate-400">
+              <div className={cn("text-sm hidden sm:flex items-center", uiTheme === "neobrutalism" ? "gap-4" : "gap-3")}>
+                <span className={cn(uiTheme === "neobrutalism" ? "font-black uppercase text-[color:var(--neo-text)] text-base" : "font-semibold text-slate-900 dark:text-slate-100 text-sm")}>{user.namaLengkap}</span>
+                {uiTheme === "neobrutalism" ? (
+                  <span className="border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] bg-[color:var(--neo-accent)] px-2 py-0.5 text-xs font-black uppercase text-[color:var(--neo-text)] shadow-[var(--neo-shadow)]">
+                  {user.role}
+                </span>
+                ) : (
+                  <Badge variant="outline" className="font-medium text-[11px] uppercase border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 text-slate-600 dark:text-slate-400">
                   {user.role}
                 </Badge>
+                )}
               </div>
             </div>
             <div className="flex items-center gap-3">
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-9 w-9 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+                className={cn(uiTheme === "neobrutalism" ? "h-10 w-10 rounded-[var(--neo-radius)] border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] bg-white shadow-[var(--neo-shadow)] hover:bg-[color:var(--neo-bg)] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[var(--neo-shadow)] flex items-center justify-center" : "h-9 w-9 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100")}
                 onClick={toggleTheme}
                 title="Ganti tema"
               >
-                {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+                {colorMode === "dark" ? <Sun className={cn("h-4 w-4", uiTheme === "neobrutalism" && "h-5 w-5 stroke-[3] text-[color:var(--neo-text)]")} /> : <Moon className={cn("h-4 w-4", uiTheme === "neobrutalism" && "h-5 w-5 stroke-[3] text-[color:var(--neo-text)]")} />}
               </Button>
               <Button
                 variant="outline"
                 size="sm"
-                className="h-9 text-xs font-medium border-slate-200 dark:border-slate-800 hover:bg-rose-50 dark:hover:bg-rose-950/50 hover:text-rose-600 dark:hover:text-rose-400 hover:border-rose-200 dark:hover:border-rose-900 transition-colors"
+                className={cn(uiTheme === "neobrutalism" ? "h-10 rounded-[var(--neo-radius)] border-[length:var(--neo-border-width)] border-[color:var(--neo-border-color)] bg-white font-black uppercase text-[color:var(--neo-text)] shadow-[var(--neo-shadow)] hover:bg-red-400 hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[var(--neo-shadow)]" : "h-9 text-xs font-medium border-slate-200 dark:border-slate-800 hover:bg-rose-50 dark:hover:bg-rose-950/50 hover:text-rose-600 dark:hover:text-rose-400 hover:border-rose-200 dark:hover:border-rose-900 transition-colors")}
                 onClick={async () => {
                   await logout();
                   navigate({ to: "/login" });
                 }}
               >
-                <LogOut className="mr-1.5 h-3.5 w-3.5" /> <span className="hidden sm:inline">Keluar</span>
+                <LogOut className={cn(uiTheme === "neobrutalism" ? "mr-2 h-5 w-5 stroke-[3]" : "mr-1.5 h-3.5 w-3.5")} /> <span className="hidden sm:inline">Keluar</span>
               </Button>
             </div>
           </header>


### PR DESCRIPTION
Restores the Neobrutalism UI conditional inline styles to the admin layout sidebar/header and the Pengaturan wrapper without affecting backend functions or non-neobrutalism themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added neobrutalism theme styling across the admin interface, including navigation, header, and controls.
  * Preserved existing default styling and dark/light mode behavior.
  * Improved readiness styling for the admin settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->