### PR TITLE
feat: improve admin sidebar navigation

### DIFF
--- a/src/routes/_authenticated/admin.tsx
+++ b/src/routes/_authenticated/admin.tsx
@@ -33,7 +33,6 @@ import {
   X,
   BookOpenCheck,
   ChevronDown,
-  ClipboardList,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -112,9 +111,7 @@ const navGroups: NavGroup[] = [
     label: "Hasil & Pelaporan",
     icon: BarChart3,
     items: [
-      { to: "/admin/hasil", label: "Hasil & Riwayat", icon: ClipboardList },
       { to: "/admin/evaluasi", label: "Evaluasi Essay", icon: PenLine },
-      { to: "/admin/laporan", label: "Laporan", icon: BarChart3 },
       { to: "/admin/leaderboard", label: "Leaderboard", icon: Trophy },
     ],
   },

--- a/src/routes/_authenticated/admin.tsx
+++ b/src/routes/_authenticated/admin.tsx
@@ -21,6 +21,7 @@ import {
   BarChart3,
   Settings,
   LogOut,
+  Trophy,
   Wrench,
   FolderOpen,
   PenLine,
@@ -31,6 +32,8 @@ import {
   Menu,
   X,
   BookOpenCheck,
+  ChevronDown,
+  ClipboardList,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -62,57 +65,72 @@ type NavItem = {
 };
 
 type NavGroup = {
+  id: string;
   label: string;
+  icon: React.ComponentType<{ className?: string }>;
   items: NavItem[];
+};
+
+const dashboardNavItem: NavItem = {
+  to: "/admin",
+  label: "Dashboard",
+  icon: LayoutDashboard,
+  exact: true,
 };
 
 const navGroups: NavGroup[] = [
   {
-    label: "Utama",
-    items: [
-      { to: "/admin", label: "Dashboard", icon: LayoutDashboard, exact: true },
-    ]
-  },
-  {
+    id: "akademik-pengguna",
     label: "Akademik & Pengguna",
+    icon: Landmark,
     items: [
       { to: "/admin/akademik", label: "Struktur Akademik", icon: Landmark },
       { to: "/admin/users", label: "Pengelola Sistem", icon: Users },
       { to: "/admin/peserta", label: "Mahasiswa / Peserta", icon: GraduationCap, exact: true },
-    ]
+    ],
   },
   {
+    id: "bank-soal-berkas",
     label: "Bank Soal & Berkas",
+    icon: BookOpen,
     items: [
       { to: "/admin/modul", label: "Bank Soal", icon: BookOpen },
       { to: "/admin/files", label: "File Manager", icon: FolderOpen },
-    ]
+    ],
   },
   {
+    id: "ujian-pelaksanaan",
     label: "Ujian & Pelaksanaan",
+    icon: FileText,
     items: [
       { to: "/admin/ujian", label: "Paket Ujian", icon: FileText },
       { to: "/admin/peserta/online", label: "Pantau Ujian Live", icon: Activity },
-    ]
+    ],
   },
   {
-    label: "Pasca Ujian",
+    id: "hasil-pelaporan",
+    label: "Hasil & Pelaporan",
+    icon: BarChart3,
     items: [
+      { to: "/admin/hasil", label: "Hasil & Riwayat", icon: ClipboardList },
       { to: "/admin/evaluasi", label: "Evaluasi Essay", icon: PenLine },
-      { to: "/admin/analitik", label: "Analitik & Laporan", icon: BarChart3 },
-    ]
+      { to: "/admin/laporan", label: "Laporan", icon: BarChart3 },
+      { to: "/admin/leaderboard", label: "Leaderboard", icon: Trophy },
+    ],
   },
   {
+    id: "sistem-bantuan",
     label: "Sistem & Bantuan",
+    icon: Settings,
     items: [
       { to: "/admin/pengaturan", label: "Pengaturan", icon: Settings },
       { to: "/admin/tools", label: "Backup & Tools", icon: Wrench },
       { to: "/admin/panduan", label: "Panduan", icon: BookOpenCheck },
-    ]
-  }
+    ],
+  },
 ];
 
-const navItems: NavItem[] = navGroups.flatMap(g => g.items);
+const navItems: NavItem[] = [dashboardNavItem, ...navGroups.flatMap((group) => group.items)];
 
 function normalizedAdminPath(pathname: string) {
   if (pathname === "/admin") return pathname;
@@ -149,6 +167,39 @@ function firstAllowedAdminPath(user: RouteUser, cfg: AppConfig) {
   return firstVisible?.to ?? "/login";
 }
 
+function isNavItemActive(item: NavItem, pathname: string) {
+  if (item.exact) return normalizedAdminPath(pathname) === item.to;
+  const routeRule = resolveAdminRouteRule(pathname);
+  const itemRule = resolveAdminRouteRule(item.to);
+  return !!(routeRule && itemRule && routeRule.key === itemRule.key);
+}
+
+function activeGroupId(pathname: string, groups: NavGroup[]) {
+  return groups.find((group) => group.items.some((item) => isNavItemActive(item, pathname)))?.id;
+}
+
+function SidebarLink({ item }: { item: NavItem }) {
+  const Icon = item.icon;
+  return (
+    <Link
+      to={item.to as never}
+      activeOptions={{ exact: item.exact }}
+      activeProps={{
+        className:
+          "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900 font-semibold shadow-sm",
+      }}
+      inactiveProps={{
+        className:
+          "text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-100",
+      }}
+      className="flex items-center gap-3 rounded-lg px-3 py-2 text-xs transition-colors duration-150 md:text-sm"
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      <span className="leading-snug">{item.label}</span>
+    </Link>
+  );
+}
+
 export const Route = createFileRoute("/_authenticated/admin")({
   beforeLoad: async ({ context, location }) => {
     const user = (context as { user: RouteUser }).user;
@@ -178,6 +229,19 @@ function AdminLayout() {
 
   const [theme, setTheme] = useState("light");
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const visibleNavGroups = React.useMemo(
+    () =>
+      navGroups
+        .map((group) => ({
+          ...group,
+          items: group.items.filter((item) => canAccessAdminPath(user, item.to, cfg)),
+        }))
+        .filter((group) => group.items.length > 0),
+    [user, cfg],
+  );
+  const [openGroupId, setOpenGroupId] = useState<string | undefined>(() =>
+    activeGroupId(pathname, visibleNavGroups),
+  );
 
   useEffect(() => {
     const stored = localStorage.getItem("theme");
@@ -201,8 +265,9 @@ function AdminLayout() {
   };
 
   useEffect(() => {
+    setOpenGroupId(activeGroupId(pathname, visibleNavGroups));
     setMobileMenuOpen(false);
-  }, [pathname]);
+  }, [pathname, visibleNavGroups]);
 
   return (
     <div className="min-h-screen bg-slate-50/50 dark:bg-slate-950 text-slate-900 dark:text-slate-100">
@@ -238,41 +303,50 @@ function AdminLayout() {
                 </Button>
               )}
             </div>
-            <nav className="flex flex-col gap-6 p-4">
-              {navGroups.map((group) => {
-                const visibleItems = group.items.filter((item) =>
-                  canAccessAdminPath(user, item.to, cfg)
-                );
+            <nav aria-label="Navigasi administrasi" className="flex flex-col gap-2 p-3">
+              {canAccessAdminPath(user, dashboardNavItem.to, cfg) && (
+                <SidebarLink item={dashboardNavItem} />
+              )}
 
-                if (visibleItems.length === 0) return null;
+              {visibleNavGroups.map((group) => {
+                const isOpen = openGroupId === group.id;
+                const GroupIcon = group.icon;
+                const panelId = `admin-nav-${group.id}`;
 
                 return (
-                  <div key={group.label} className="flex flex-col gap-1.5">
-                    <h3 className="px-3 text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
-                      {group.label}
-                    </h3>
-                    <div className="flex flex-col gap-1">
-                      {visibleItems.map((n) => {
-                        const Icon = n.icon;
-                        return (
-                          <Link
-                            key={n.to}
-                            to={n.to as never}
-                            activeOptions={{ exact: n.exact }}
-                            activeProps={{
-                              className: "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900 font-semibold shadow-sm"
-                            }}
-                            inactiveProps={{
-                              className: "text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-100"
-                            }}
-                            className="flex items-center gap-3 px-3 py-2 text-xs md:text-sm rounded-lg transition-colors duration-150"
-                          >
-                            <Icon className="h-4 w-4 shrink-0" />
-                            <span className="leading-snug">{n.label}</span>
-                          </Link>
-                        );
-                      })}
-                    </div>
+                  <div key={group.id}>
+                    <button
+                      type="button"
+                      aria-expanded={isOpen}
+                      aria-controls={panelId}
+                      onClick={() => setOpenGroupId(isOpen ? undefined : group.id)}
+                      className={cn(
+                        "flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider transition-colors duration-150",
+                        group.items.some((item) => isNavItemActive(item, pathname))
+                          ? "bg-slate-100 text-slate-900 dark:bg-slate-900 dark:text-slate-100"
+                          : "text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-900 dark:hover:text-slate-100",
+                      )}
+                    >
+                      <span className="flex min-w-0 items-center gap-3">
+                        <GroupIcon className="h-4 w-4 shrink-0" />
+                        <span className="truncate">{group.label}</span>
+                      </span>
+                      <ChevronDown
+                        aria-hidden="true"
+                        className={cn(
+                          "h-4 w-4 shrink-0 transition-transform duration-150",
+                          isOpen && "rotate-180",
+                        )}
+                      />
+                    </button>
+
+                    {isOpen && (
+                      <div id={panelId} className="ml-4 mt-1 flex flex-col gap-1 border-l border-slate-200 pl-2 dark:border-slate-800">
+                        {group.items.map((item) => (
+                          <SidebarLink key={item.to} item={item} />
+                        ))}
+                      </div>
+                    )}
                   </div>
                 );
               })}


### PR DESCRIPTION
Focused replacement preserving the compatible sidebar accordion and navigation contributions from #73 and #74 by @Hzkun001.

- keeps a single open accordion group and expands the active route group
- conditionally renders open panels so collapsed links are not keyboard-focusable
- filters every item through the existing `ADMIN_ROUTE_RULES` / `canAccessAdminPath` policy
- removes the unauthorized `/admin/analitik` item and exposes the policy-backed results/reporting destinations
- avoids the aggregate dashboard history, route-level theme markers, speculative GPU claims, and contributor-branch rewrites

Contributor branches and PRs #73/#74 remain unchanged pending independent review and merge of this replacement.