### PR TITLE
feat: add optional exam calculator

### DIFF
--- a/prisma/migrations/20260802150000_add_ujian_calculator/migration.sql
+++ b/prisma/migrations/20260802150000_add_ujian_calculator/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Ujian" ADD COLUMN "allowCalculator" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,6 +139,7 @@ model Ujian {
   maxPindahTab     Int          @default(3)
   blokirShortcut   Boolean      @default(true)
   mode             String       @default("online") // "online" | "offline"
+  allowCalculator  Boolean      @default(false)
   createdBy        String
   createdAt        BigInt
   creator          User         @relation("UjianCreator", fields: [createdBy], references: [id])

--- a/src/components/cbt/ExamCalculator.tsx
+++ b/src/components/cbt/ExamCalculator.tsx
@@ -1,0 +1,239 @@
+import { Delete } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  applyUnary,
+  backspaceCalculator,
+  type CalculatorOperator,
+  type CalculatorUnary,
+  chooseOperator,
+  equalsCalculator,
+  INITIAL_CALCULATOR_STATE,
+  inputDecimal,
+  inputDigit,
+} from "@/lib/cbt/calculator";
+import { cn } from "@/lib/utils";
+
+export function ExamCalculator() {
+  const [state, setState] = useState(INITIAL_CALCULATOR_STATE);
+  const baseClass = "h-10 text-sm font-semibold";
+  const operatorClass = cn(
+    baseClass,
+    "bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-950 dark:text-blue-300",
+  );
+
+  const digit = (value: string) => setState((current) => inputDigit(current, value));
+  const operator = (value: CalculatorOperator) =>
+    setState((current) => chooseOperator(current, value));
+  const unary = (value: CalculatorUnary) => setState((current) => applyUnary(current, value));
+
+  return (
+    <div className="mx-auto flex w-full max-w-xs flex-col gap-2">
+      <output
+        aria-live="polite"
+        aria-label="Hasil kalkulator"
+        className="flex h-20 items-end justify-end overflow-hidden rounded-lg bg-slate-900 p-3 text-right font-mono text-2xl tracking-wider text-white"
+      >
+        <span className="w-full truncate">{state.display}</span>
+      </output>
+
+      <div className="grid grid-cols-3 gap-1.5">
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => unary("sqrt")}
+          aria-label="Akar kuadrat"
+        >
+          √x
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => unary("square")}
+          aria-label="Kuadrat"
+        >
+          x²
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => unary("percent")}
+          aria-label="Persen"
+        >
+          %
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-4 gap-1.5">
+        <Button
+          type="button"
+          variant="secondary"
+          className={cn(baseClass, "text-red-600")}
+          onClick={() => setState(INITIAL_CALCULATOR_STATE)}
+          aria-label="Bersihkan kalkulator"
+        >
+          AC
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => setState(backspaceCalculator)}
+          aria-label="Hapus digit"
+        >
+          <Delete className="h-4 w-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={operatorClass}
+          onClick={() => operator("/")}
+          aria-label="Bagi"
+        >
+          ÷
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={operatorClass}
+          onClick={() => operator("*")}
+          aria-label="Kali"
+        >
+          ×
+        </Button>
+
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => digit("7")}
+          aria-label="Tujuh"
+        >
+          7
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => digit("8")}
+          aria-label="Delapan"
+        >
+          8
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => digit("9")}
+          aria-label="Sembilan"
+        >
+          9
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={operatorClass}
+          onClick={() => operator("-")}
+          aria-label="Kurang"
+        >
+          −
+        </Button>
+
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => digit("4")}
+          aria-label="Empat"
+        >
+          4
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => digit("5")}
+          aria-label="Lima"
+        >
+          5
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => digit("6")}
+          aria-label="Enam"
+        >
+          6
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={operatorClass}
+          onClick={() => operator("+")}
+          aria-label="Tambah"
+        >
+          +
+        </Button>
+
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => digit("1")}
+          aria-label="Satu"
+        >
+          1
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => digit("2")}
+          aria-label="Dua"
+        >
+          2
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => digit("3")}
+          aria-label="Tiga"
+        >
+          3
+        </Button>
+        <Button
+          type="button"
+          className="row-span-2 h-full font-bold"
+          onClick={() => setState(equalsCalculator)}
+          aria-label="Hitung hasil"
+        >
+          =
+        </Button>
+
+        <Button
+          type="button"
+          variant="secondary"
+          className={cn(baseClass, "col-span-2")}
+          onClick={() => digit("0")}
+          aria-label="Nol"
+        >
+          0
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className={baseClass}
+          onClick={() => setState(inputDecimal)}
+          aria-label="Desimal"
+        >
+          .
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/cbt/calculator.ts
+++ b/src/lib/cbt/calculator.ts
@@ -1,0 +1,122 @@
+export type CalculatorOperator = "+" | "-" | "*" | "/";
+export type CalculatorUnary = "sqrt" | "square" | "percent";
+
+export type CalculatorState = {
+  display: string;
+  accumulator: number | null;
+  operator: CalculatorOperator | null;
+  replaceDisplay: boolean;
+};
+
+export const INITIAL_CALCULATOR_STATE: CalculatorState = {
+  display: "0",
+  accumulator: null,
+  operator: null,
+  replaceDisplay: false,
+};
+
+function finiteDisplay(value: number): string | null {
+  if (!Number.isFinite(value)) return null;
+  return String(Number(value.toPrecision(12)));
+}
+
+function errorState(): CalculatorState {
+  return {
+    ...INITIAL_CALCULATOR_STATE,
+    display: "Error",
+    replaceDisplay: true,
+  };
+}
+
+function calculate(left: number, operator: CalculatorOperator, right: number): number | null {
+  if (operator === "/" && right === 0) return null;
+  const value =
+    operator === "+"
+      ? left + right
+      : operator === "-"
+        ? left - right
+        : operator === "*"
+          ? left * right
+          : left / right;
+  return Number.isFinite(value) ? value : null;
+}
+
+export function inputDigit(state: CalculatorState, digit: string): CalculatorState {
+  if (!/^\d$/.test(digit)) return state;
+  if (state.display === "Error" || state.replaceDisplay) {
+    return {
+      ...state,
+      display: digit,
+      accumulator: state.display === "Error" ? null : state.accumulator,
+      operator: state.display === "Error" ? null : state.operator,
+      replaceDisplay: false,
+    };
+  }
+  return {
+    ...state,
+    display: state.display === "0" ? digit : `${state.display}${digit}`,
+  };
+}
+
+export function inputDecimal(state: CalculatorState): CalculatorState {
+  if (state.display === "Error" || state.replaceDisplay) {
+    return {
+      ...state,
+      display: "0.",
+      accumulator: state.display === "Error" ? null : state.accumulator,
+      operator: state.display === "Error" ? null : state.operator,
+      replaceDisplay: false,
+    };
+  }
+  if (state.display.includes(".")) return state;
+  return { ...state, display: `${state.display}.` };
+}
+
+export function backspaceCalculator(state: CalculatorState): CalculatorState {
+  if (state.display === "Error" || state.replaceDisplay) return INITIAL_CALCULATOR_STATE;
+  return {
+    ...state,
+    display: state.display.length === 1 ? "0" : state.display.slice(0, -1),
+  };
+}
+
+export function chooseOperator(
+  state: CalculatorState,
+  operator: CalculatorOperator,
+): CalculatorState {
+  if (state.display === "Error") return state;
+  const current = Number(state.display);
+  if (!Number.isFinite(current)) return errorState();
+  if (state.accumulator !== null && state.operator) {
+    if (state.replaceDisplay) return { ...state, operator };
+    const result = calculate(state.accumulator, state.operator, current);
+    const display = result === null ? null : finiteDisplay(result);
+    if (display === null) return errorState();
+    return { display, accumulator: result, operator, replaceDisplay: true };
+  }
+  return { ...state, accumulator: current, operator, replaceDisplay: true };
+}
+
+export function equalsCalculator(state: CalculatorState): CalculatorState {
+  if (state.display === "Error" || state.accumulator === null || !state.operator) return state;
+  const result = calculate(state.accumulator, state.operator, Number(state.display));
+  const display = result === null ? null : finiteDisplay(result);
+  if (display === null) return errorState();
+  return { display, accumulator: null, operator: null, replaceDisplay: true };
+}
+
+export function applyUnary(state: CalculatorState, operation: CalculatorUnary): CalculatorState {
+  if (state.display === "Error") return state;
+  const current = Number(state.display);
+  const result =
+    operation === "sqrt"
+      ? current < 0
+        ? null
+        : Math.sqrt(current)
+      : operation === "square"
+        ? current * current
+        : current / 100;
+  const display = result === null ? null : finiteDisplay(result);
+  if (display === null) return errorState();
+  return { ...state, display, replaceDisplay: true };
+}

--- a/src/lib/cbt/types.ts
+++ b/src/lib/cbt/types.ts
@@ -149,6 +149,7 @@ export const UjianSchema = z.object({
 	maxPindahTab: z.number().int().nonnegative().default(3),
 	blokirShortcut: z.boolean().default(true),
 	mode: z.enum(["online", "offline"]).default("online"),
+	allowCalculator: z.boolean().default(false),
 	createdBy: z.string(),
 	createdAt: z.number(),
 });

--- a/src/lib/server/repos/mappers.ts
+++ b/src/lib/server/repos/mappers.ts
@@ -154,6 +154,7 @@ export function mapUjian(
 		maxPindahTab: row.maxPindahTab,
 		blokirShortcut: row.blokirShortcut,
 		mode: (row.mode ?? "online") as "online" | "offline",
+		allowCalculator: row.allowCalculator,
 		createdBy: row.createdBy,
 		createdAt: Number(row.createdAt),
 	};

--- a/src/routes/_authenticated/admin.ujian.$id.tsx
+++ b/src/routes/_authenticated/admin.ujian.$id.tsx
@@ -498,6 +498,25 @@ function UjianEditor() {
       </Card>
 
       <Card>
+        <CardContent className="space-y-3 p-4">
+          <h3 className="font-medium">Alat bantu ujian</h3>
+          <div className="flex items-center justify-between rounded border p-2">
+            <div>
+              <Label htmlFor="allow-calculator">Kalkulator ujian</Label>
+              <p className="text-xs text-muted-foreground">
+                Izinkan peserta membuka kalkulator selama ujian.
+              </p>
+            </div>
+            <Switch
+              id="allow-calculator"
+              checked={u.allowCalculator}
+              onCheckedChange={(value) => set("allowCalculator", value)}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
         <CardContent className="p-4 space-y-3">
           <h3 className="font-medium">Tampilan hasil & anti-cheat</h3>
           <div className="flex items-center justify-between rounded border p-2">

--- a/src/routes/_authenticated/admin.ujian.tsx
+++ b/src/routes/_authenticated/admin.ujian.tsx
@@ -60,6 +60,7 @@ function UjianList() {
       maxPindahTab: 3,
       blokirShortcut: true,
       mode: "online",
+      allowCalculator: false,
       createdBy: user.id,
       createdAt: Date.now(),
     };

--- a/src/routes/_authenticated/peserta.ujian.$id.kerjakan.tsx
+++ b/src/routes/_authenticated/peserta.ujian.$id.kerjakan.tsx
@@ -4,7 +4,7 @@ import type { SesiUjian, Ujian } from "@/lib/cbt/types";
 import { cn } from "@/lib/utils";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { LayoutGrid, X, ChevronLeft, ChevronRight, Flag, CheckCircle2, AlertCircle, Type, Clock } from "lucide-react";
+import { LayoutGrid, X, ChevronLeft, ChevronRight, Flag, CheckCircle2, AlertCircle, Type, Clock, Calculator } from "lucide-react";
 import {
   createFileRoute,
   useNavigate,
@@ -14,6 +14,14 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AudioPlayer } from "@/components/cbt/AudioPlayer";
 import { RichView } from "@/components/cbt/RichEditor";
+import { ExamCalculator } from "@/components/cbt/ExamCalculator";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 
 export const Route = createFileRoute(
   "/_authenticated/peserta/ujian/$id/kerjakan",
@@ -62,6 +70,27 @@ function gradeSesi(sesi: SesiUjian, ujian: Ujian) {
   }
 
   return currentSesi;
+}
+
+function CalculatorAction({ ujian }: { ujian: Ujian }) {
+  if (!ujian.allowCalculator) return null;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="mt-4 w-full">
+          <Calculator className="mr-2 h-4 w-4" aria-hidden="true" />
+          Buka Kalkulator
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[90dvh] w-[calc(100%_-_2rem)] max-w-sm overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Kalkulator Ujian</DialogTitle>
+        </DialogHeader>
+        <ExamCalculator />
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 function RouteComponent() {
@@ -468,7 +497,8 @@ function RouteComponent() {
         <div className="hidden md:flex flex-col w-80 bg-slate-50/50 dark:bg-slate-950/30 border-l border-slate-200 dark:border-slate-800">
           <div className="p-6 border-b border-slate-200 dark:border-slate-800 bg-white/50 dark:bg-slate-900/50 backdrop-blur-sm">
             <h3 className="font-extrabold text-slate-800 dark:text-slate-200 text-lg tracking-tight">Navigasi Soal</h3>
-            
+            <CalculatorAction ujian={ujian} />
+
             <div className="mt-4 flex flex-col gap-2">
               <div className="flex items-center gap-3 text-sm font-medium text-slate-600 dark:text-slate-400">
                 <div className="w-4 h-4 rounded-full bg-primary shadow-sm" /> Sudah Dijawab
@@ -544,8 +574,9 @@ function RouteComponent() {
           
           <div className="flex-1 overflow-y-auto p-6">
             <div className="max-w-xl mx-auto">
-              
-              <div className="flex justify-between items-center bg-white dark:bg-slate-900 p-4 rounded-2xl border border-slate-200 dark:border-slate-800 mb-8 shadow-sm">
+              <CalculatorAction ujian={ujian} />
+
+              <div className="flex justify-between items-center bg-white dark:bg-slate-900 p-4 rounded-2xl border border-slate-200 dark:border-slate-800 mb-8 mt-6 shadow-sm">
                 <div className="flex flex-col items-center">
                   <div className="w-4 h-4 rounded-full bg-primary shadow-sm mb-1" />
                   <span className="text-xs font-semibold text-slate-500">Sudah</span>

--- a/tests/unit/exam-calculator.test.mjs
+++ b/tests/unit/exam-calculator.test.mjs
@@ -1,0 +1,59 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  INITIAL_CALCULATOR_STATE,
+  applyUnary,
+  chooseOperator,
+  equalsCalculator,
+  inputDecimal,
+  inputDigit,
+} from "../../src/lib/cbt/calculator.ts";
+
+function digits(state, value) {
+  return [...value].reduce(
+    (current, character) =>
+      character === "." ? inputDecimal(current) : inputDigit(current, character),
+    state,
+  );
+}
+
+function binary(left, operator, right) {
+  let state = digits(INITIAL_CALCULATOR_STATE, left);
+  state = chooseOperator(state, operator);
+  state = digits(state, right);
+  return equalsCalculator(state);
+}
+
+test("calculator executes chained operations in entered sequence", () => {
+  let state = digits(INITIAL_CALCULATOR_STATE, "2");
+  state = chooseOperator(state, "+");
+  state = digits(state, "3");
+  state = chooseOperator(state, "*");
+  state = digits(state, "4");
+  assert.equal(equalsCalculator(state).display, "20");
+
+  let replacement = digits(INITIAL_CALCULATOR_STATE, "8");
+  replacement = chooseOperator(replacement, "+");
+  replacement = chooseOperator(replacement, "*");
+  replacement = digits(replacement, "2");
+  assert.equal(equalsCalculator(replacement).display, "16");
+});
+
+test("calculator accepts one decimal point and calculates decimal input", () => {
+  let state = digits(INITIAL_CALCULATOR_STATE, "1.5");
+  state = inputDecimal(state);
+  assert.equal(state.display, "1.5");
+  assert.equal(binary("1.5", "+", "2.25").display, "3.75");
+});
+
+test("calculator reports divide-by-zero and recovers on a new digit", () => {
+  const error = binary("8", "/", "0");
+  assert.equal(error.display, "Error");
+  const recovered = inputDigit(error, "7");
+  assert.deepEqual(recovered, { ...INITIAL_CALCULATOR_STATE, display: "7" });
+});
+
+test("calculator square root rejects invalid domains", () => {
+  assert.equal(applyUnary(digits(INITIAL_CALCULATOR_STATE, "81"), "sqrt").display, "9");
+  assert.equal(applyUnary(binary("0", "-", "1"), "sqrt").display, "Error");
+});


### PR DESCRIPTION
Focused current-main replacement preserving the calculator contribution from #78 by @Jedijedai.

Included:
- optional per-exam `allowCalculator` persisted through the existing Ujian server/repository path
- forward Prisma migration
- deterministic calculator without eval/new Function
- participant desktop/mobile dialogs
- focused Node unit coverage

Intentionally excluded from #78: medical normal-value tables/data, `allowNormalValues`, `diff_users.txt`, `scratch/*`, root/layout Neobrutalism changes from #76, Redis, dashboard/sidebar, and aggregate artifacts.

Source PR #78 and contributor branch remain untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional calculator for exam participants, available on desktop and mobile when enabled.
  * Added calculator controls for arithmetic, decimals, backspace, clearing, square roots, and error handling.
  * Added an exam setting allowing administrators to enable or disable the calculator.

* **Bug Fixes**
  * Added safeguards for invalid calculations, including division by zero and invalid square roots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->