### PR TITLE
fix(security): harden issue #150 boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Format ini mengikuti prinsip [Keep a Changelog](https://keepachangelog.com/id/1.
 
 ### Security
 
+- Perketat validasi mutation server, scope akses file operator, dan batas ukuran/quota upload; amankan default production (#150).
+
 ### Deprecated
 
 ### Removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ ENV NODE_ENV=production \
 
 EXPOSE 8080
 
-CMD ["sh", "-c", "npx prisma migrate deploy && if [ \"${SEED_DEMO:-false}\" = true ] && [ ! -f /app/data/.demo-seeded ]; then NODE_ENV=development npm run prisma:seed && touch /app/data/.demo-seeded; fi && npm run preview -- --host 0.0.0.0 --port 8080"]
+CMD ["sh", "-c", "npx prisma migrate deploy && if [ \"${SEED_DEMO:-false}\" = true ] && [ ! -f /app/data/.demo-seeded ]; then npm run prisma:seed && touch /app/data/.demo-seeded; fi && npm run preview -- --host 0.0.0.0 --port 8080"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,8 +6,9 @@ services:
     environment:
       NODE_ENV: production
       DATABASE_URL: file:/app/data/cbt.db
-      SEED_DEMO: "true"
-      SESSION_COOKIE_SECURE: "false"
+      ADMIN_PASSWORD: "${ADMIN_PASSWORD:?set ADMIN_PASSWORD for production}"
+      SEED_DEMO: "${SEED_DEMO:-false}"
+      SESSION_COOKIE_SECURE: "${SESSION_COOKIE_SECURE:-true}"
     volumes:
       - cbt-data:/app/data
     ports:

--- a/src/lib/cbt/repos.ts
+++ b/src/lib/cbt/repos.ts
@@ -235,14 +235,14 @@ function runEntityMutation(
 	let mutationPromise: Promise<{ ok: boolean; error?: string }>;
 	
 	switch (entity) {
-		case "users": mutationPromise = mutateUserServer({ data: { action, payload } }); break;
+		case "users": mutationPromise = mutateUserServer({ data: { action, payload: payload as never } }); break;
 
-		case "modul": mutationPromise = mutateModulServer({ data: { action, payload } }); break;
-		case "topik": mutationPromise = mutateTopikServer({ data: { action, payload } }); break;
-		case "soal": mutationPromise = mutateSoalServer({ data: { action, payload } }); break;
-		case "ujian": mutationPromise = mutateUjianServer({ data: { action, payload } }); break;
-		case "token": mutationPromise = mutateTokenServer({ data: { action, payload } }); break;
-		case "sesi": mutationPromise = mutateSesiServer({ data: { action, payload } }); break;
+		case "modul": mutationPromise = mutateModulServer({ data: { action, payload: payload as never } }); break;
+		case "topik": mutationPromise = mutateTopikServer({ data: { action, payload: payload as never } }); break;
+		case "soal": mutationPromise = mutateSoalServer({ data: { action, payload: payload as never } }); break;
+		case "ujian": mutationPromise = mutateUjianServer({ data: { action, payload: payload as never } }); break;
+		case "token": mutationPromise = mutateTokenServer({ data: { action, payload: payload as never } }); break;
+		case "sesi": mutationPromise = mutateSesiServer({ data: { action, payload: payload as never } }); break;
 		case "unitAkademik": mutationPromise = mutateUnitAkademikServer({ data: { action: action as any, payload } }); break;
 		case "tahunAkademik": mutationPromise = mutateTahunAkademikServer({ data: { action: action as any, payload } }); break;
 		case "semester": mutationPromise = mutateSemesterServer({ data: { action: action as any, payload } }); break;

--- a/src/lib/server/backup/functions.ts
+++ b/src/lib/server/backup/functions.ts
@@ -16,7 +16,7 @@ import {
 	UjianSchema,
 	UserSchema,
 } from "@/lib/cbt/types";
-import type { User, UnitAkademik, MataKuliah, PenawaranMataKuliah, Modul, Topik, Soal, Ujian, TokenUjian, TokenClaim, SesiUjian } from "@/lib/cbt/types";
+import type { AppConfig, User, UnitAkademik, MataKuliah, PenawaranMataKuliah, Modul, Topik, Soal, Ujian, TokenUjian, TokenClaim, SesiUjian } from "@/lib/cbt/types";
 
 import { stringifyJson, toBigInt } from "../db/json";
 

--- a/src/lib/server/backup/functions.ts
+++ b/src/lib/server/backup/functions.ts
@@ -2,27 +2,41 @@ import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { prisma } from "../db/prisma";
 import { requireAdminResult } from "../db/auth";
-import type { User, UnitAkademik, MataKuliah, PenawaranMataKuliah, Modul, Topik, Soal, Ujian, TokenUjian, TokenClaim, SesiUjian, AppConfig } from "@/lib/cbt/types";
+import {
+	ConfigSchema,
+	MataKuliahSchema,
+	ModulSchema,
+	PenawaranMataKuliahSchema,
+	SesiUjianSchema,
+	SoalSchema,
+	TokenClaimSchema,
+	TokenUjianSchema,
+	TopikSchema,
+	UnitAkademikSchema,
+	UjianSchema,
+	UserSchema,
+} from "@/lib/cbt/types";
+import type { User, UnitAkademik, MataKuliah, PenawaranMataKuliah, Modul, Topik, Soal, Ujian, TokenUjian, TokenClaim, SesiUjian } from "@/lib/cbt/types";
 
 import { stringifyJson, toBigInt } from "../db/json";
 
+const backupImportSchema = z.object({
+	users: z.array(UserSchema),
+	unitAkademik: z.array(UnitAkademikSchema),
+	mataKuliah: z.array(MataKuliahSchema),
+	modul: z.array(ModulSchema),
+	topik: z.array(TopikSchema),
+	soal: z.array(SoalSchema),
+	ujian: z.array(UjianSchema),
+	penawaran: z.array(PenawaranMataKuliahSchema).default([]),
+	token: z.array(TokenUjianSchema),
+	tokenClaims: z.array(TokenClaimSchema).default([]),
+	sesi: z.array(SesiUjianSchema),
+	config: ConfigSchema,
+}).strict();
+
 export const importBackupServer = createServerFn({ method: "POST" })
-	.validator(
-		z.object({
-			users: z.array(z.any()),
-			unitAkademik: z.array(z.any()),
-			mataKuliah: z.array(z.any()),
-			modul: z.array(z.any()),
-			topik: z.array(z.any()),
-			soal: z.array(z.any()),
-			ujian: z.array(z.any()),
-			penawaran: z.array(z.any()).default([]),
-			token: z.array(z.any()),
-			tokenClaims: z.array(z.any()).default([]),
-			sesi: z.array(z.any()),
-			config: z.any(),
-		}),
-	)
+	.validator(backupImportSchema)
 	.handler(async ({ data }) => {
 		const auth = await requireAdminResult();
 		if (!auth.ok) return { ok: false as const, error: auth.error };

--- a/src/lib/server/files/functions.ts
+++ b/src/lib/server/files/functions.ts
@@ -6,8 +6,13 @@ import { z } from "zod";
 import { prisma } from "@/lib/server/db/prisma";
 import { parseJson } from "@/lib/server/db/json";
 import { readSessionToken, validateSession } from "@/lib/server/db/session";
-import { pesertaCanTouchUjian } from "@/lib/server/db/auth";
+import {
+  operatorCanTouchTopikId,
+  operatorCanTouchUjian,
+  pesertaCanTouchUjian,
+} from "@/lib/server/db/auth";
 import type { NavKey, Role } from "@/lib/cbt/types";
+import type { UserRow } from "@/lib/server/repos/mappers";
 
 const uploadsDir = [process.cwd(), "data", "uploads"] as const;
 const DEFAULT_OPERATOR_ROLE_ACCESS: NavKey[] = [
@@ -40,6 +45,78 @@ const fileSchema = z.object({
   createdAt: z.number(),
   extension: z.string().default(""),
   jurusanId: z.string().optional(),
+});
+
+export const MAX_FILE_BYTES = 10 * 1024 * 1024;
+export const MAX_STORAGE_BYTES = 500 * 1024 * 1024;
+const ALLOWED_FILE_EXTENSIONS: Record<string, readonly string[]> = {
+  "image/jpeg": [".jpg", ".jpeg"],
+  "image/png": [".png"],
+  "image/gif": [".gif"],
+  "image/webp": [".webp"],
+  "audio/mpeg": [".mp3"],
+  "audio/wav": [".wav"],
+  "audio/ogg": [".ogg"],
+  "audio/webm": [".webm"],
+  "audio/mp4": [".m4a", ".mp4"],
+};
+const ALLOWED_FILE_MIMES = Object.keys(ALLOWED_FILE_EXTENSIONS) as [string, ...string[]];
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+function decodedBase64Size(value: string): number {
+  if (!BASE64_PATTERN.test(value)) return -1;
+  const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+  return (value.length / 4) * 3 - padding;
+}
+
+function extensionFromName(name: string): string {
+  const match = /\.[^.]+$/.exec(name);
+  return match?.[0].toLowerCase() ?? "";
+}
+
+function validateMediaFile(
+  item: { name: string; mime: string; dataBase64: string; extension?: string; size?: number },
+  ctx: z.RefinementCtx,
+): void {
+  const decodedSize = decodedBase64Size(item.dataBase64);
+  if (decodedSize < 0) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["dataBase64"], message: "Data file bukan base64 yang valid" });
+    return;
+  }
+  if (decodedSize > MAX_FILE_BYTES) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["dataBase64"], message: `Ukuran file maksimal ${MAX_FILE_BYTES} byte` });
+  }
+  if (item.size !== undefined && decodedSize !== item.size) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["size"], message: "Ukuran file tidak sesuai isi" });
+  }
+  const extension = (item.extension ?? extensionFromName(item.name)).toLowerCase();
+  if (!ALLOWED_FILE_EXTENSIONS[item.mime]?.includes(extension)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["mime"], message: "Tipe dan ekstensi file tidak diizinkan" });
+  }
+}
+
+const uploadFileSchema = z.object({
+  name: z.string().trim().min(1).max(255).refine((name) => !/[\\/\0]/.test(name), "Nama file tidak valid"),
+  mime: z.enum(ALLOWED_FILE_MIMES),
+  dataBase64: z.string().min(1),
+  jurusanId: z.string().min(1).optional(),
+}).superRefine(validateMediaFile);
+
+const fileBackupSchema = z.object({
+  id: z.string().regex(/^[A-Za-z0-9_-]+$/),
+  name: z.string().trim().min(1).max(255).refine((name) => !/[\\/\0]/.test(name), "Nama file tidak valid"),
+  mime: z.enum(ALLOWED_FILE_MIMES),
+  size: z.number().int().nonnegative(),
+  createdAt: z.number().finite(),
+  extension: z.string().regex(/^\.[A-Za-z0-9]{1,16}$/),
+  dataBase64: z.string().min(1),
+  jurusanId: z.string().min(1).optional(),
+}).superRefine(validateMediaFile);
+const importFilesSchema = z.array(fileBackupSchema).max(5000).superRefine((items, ctx) => {
+  const totalBytes = items.reduce((total, item) => total + item.size, 0);
+  if (totalBytes > MAX_STORAGE_BYTES) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Kuota penyimpanan maksimal ${MAX_STORAGE_BYTES} byte` });
+  }
 });
 
 async function pathApi() {
@@ -223,6 +300,48 @@ async function pesertaCanAccessFile(
   return allowed.has(fileId);
 }
 
+async function operatorCanAccessFile(
+  caller: UserRow,
+  fileId: string,
+  meta: StoredFileRecord,
+): Promise<boolean> {
+  if (caller.role === "super_admin") return true;
+  if (caller.role !== "admin_prodi" && caller.role !== "evaluator") return false;
+  if (meta.jurusanId && meta.jurusanId !== caller.unitId) return false;
+
+  const marker = `file://${fileId}`;
+  const [soals, ujians] = await Promise.all([
+    prisma.soal.findMany({
+      where: {
+        OR: [
+          { audioFileId: fileId },
+          { detail: { contains: marker } },
+          { pembahasan: { contains: marker } },
+          { jawaban: { some: { detail: { contains: marker } } } },
+        ],
+      },
+      select: { topikId: true },
+    }),
+    prisma.ujian.findMany({
+      where: { deskripsi: { contains: marker } },
+      select: { id: true },
+    }),
+  ]);
+
+  for (const soal of soals) {
+    if (await operatorCanTouchTopikId(caller, soal.topikId)) return true;
+  }
+  for (const ujian of ujians) {
+    if (await operatorCanTouchUjian(caller, ujian.id)) return true;
+  }
+
+  // Unreferenced files follow the file-manager list boundary: only the
+  // operator's own jurusan and an enabled files nav are readable.
+  return !soals.length && !ujians.length
+    && meta.jurusanId === caller.unitId
+    && await operatorHasFilesAccess(caller.role);
+}
+
 export const listStoredFiles = createServerFn({ method: "GET" }).handler(async () => {
   const auth = await requireFileManagerAccess();
   if (!auth.ok) throw new Error(auth.error);
@@ -233,22 +352,21 @@ export const listStoredFiles = createServerFn({ method: "GET" }).handler(async (
 });
 
 export const uploadStoredFile = createServerFn({ method: "POST" })
-  .validator(
-    z.object({
-      name: z.string().min(1),
-      mime: z.string().min(1),
-      dataBase64: z.string().min(1),
-      jurusanId: z.string().optional(),
-    }),
-  )
+  .validator(uploadFileSchema)
   .handler(async ({ data }) => {
     const auth = await requireFileManagerAccess();
     if (!auth.ok) throw new Error(auth.error);
 
+    const currentBytes = (await listMetas()).reduce((total, file) => total + file.size, 0);
+    const incomingBytes = decodedBase64Size(data.dataBase64);
+    if (currentBytes + incomingBytes > MAX_STORAGE_BYTES) {
+      throw new Error(`Kuota penyimpanan maksimal ${MAX_STORAGE_BYTES} byte`);
+    }
+
     await ensureUploadsDir();
     const [{ extname }, { writeFile }] = await Promise.all([pathApi(), fsApi()]);
     const id = uid("f_");
-    const extension = extname(data.name).slice(0, 16);
+    const extension = extname(data.name).toLowerCase();
     const buffer = Buffer.from(data.dataBase64, "base64");
     const meta: StoredFileRecord = {
       id,
@@ -285,23 +403,16 @@ export const getStoredFileUrl = createServerFn({ method: "GET" })
   .handler(async ({ data }) => {
     const caller = await requireCaller();
     if (!caller) throw new Error("Forbidden");
-
-    // Authorize by role (Issue #2). Admin and operators may read any blob:
-    // operators legitimately view exam/soal images (hasil/evaluasi/laporan)
-    // based on their topik scope, independent of the file-manager nav, so
-    // gating reads behind the "files" management nav would break those images.
-    // A peserta is scoped to files referenced by exams/soal they can access;
-    // everyone else is denied.
-    if (caller.role === "super_admin" || caller.role === "admin_prodi" || caller.role === "evaluator") {
-      // allowed
-    } else if (caller.role === "mahasiswa") {
-      if (!(await pesertaCanAccessFile(caller, data.id))) throw new Error("Forbidden");
-    } else {
-      throw new Error("Forbidden");
-    }
-
     const meta = await readMeta(data.id);
     if (!meta) return null;
+
+    if (caller.role === "admin_prodi" || caller.role === "evaluator") {
+      if (!(await operatorCanAccessFile(caller, data.id, meta))) throw new Error("Forbidden");
+    } else if (caller.role === "mahasiswa") {
+      if (!(await pesertaCanAccessFile(caller, data.id))) throw new Error("Forbidden");
+    } else if (caller.role !== "super_admin") {
+      throw new Error("Forbidden");
+    }
 
     const [{ stat, readFile }, absPath] = await Promise.all([
       fsApi(),
@@ -316,17 +427,6 @@ export const getStoredFileUrl = createServerFn({ method: "GET" })
       dataBase64: body.toString("base64"),
     };
   });
-
-const fileBackupSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  mime: z.string(),
-  size: z.number(),
-  createdAt: z.number(),
-  extension: z.string(),
-  dataBase64: z.string(),
-  jurusanId: z.string().optional(),
-});
 
 export const exportFilesServer = createServerFn({ method: "GET" }).handler(async () => {
   const auth = await requireAdmin();
@@ -344,7 +444,7 @@ export const exportFilesServer = createServerFn({ method: "GET" }).handler(async
 });
 
 export const importFilesServer = createServerFn({ method: "POST" })
-  .validator(z.array(fileBackupSchema))
+  .validator(importFilesSchema)
   .handler(async ({ data }) => {
     const auth = await requireAdmin();
     if (!auth.ok) return { ok: false as const, error: auth.error };
@@ -353,11 +453,10 @@ export const importFilesServer = createServerFn({ method: "POST" })
     const [{ resolve, sep }, { writeFile }] = await Promise.all([pathApi(), fsApi()]);
     const baseDir = await resolveUploadsDir();
     for (const item of data) {
-      if (!/^[A-Za-z0-9_-]+$/.test(item.id)) continue;
-      if (item.extension !== "" && !/^\.[A-Za-z0-9]{1,16}$/.test(item.extension)) continue;
       const blobPath = resolve(await filePath(item.id, item.extension));
-      if (!blobPath.startsWith(baseDir + sep)) continue;
       const buffer = Buffer.from(item.dataBase64, "base64");
+      if (buffer.length !== item.size) throw new Error(`Ukuran file ${item.name} tidak sesuai`);
+      if (!blobPath.startsWith(baseDir + sep)) throw new Error("Path file tidak valid");
       await writeFile(blobPath, buffer);
       const meta: StoredFileRecord = {
         id: item.id,

--- a/src/lib/server/modul/functions.ts
+++ b/src/lib/server/modul/functions.ts
@@ -3,7 +3,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { prisma } from "../db/prisma";
-import { 
+import {
 	requireCaller, 
 	seedIfNeeded,
 	operatorHasNav,
@@ -12,6 +12,7 @@ import {
 	operatorCanTouchSoal,
 	operatorCanTouchTopikId
 } from "../db/auth";
+import { ModulSchema, SoalSchema, TopikSchema } from "@/lib/cbt/types";
 import type { Modul, Topik, Soal } from "@/lib/cbt/types";
 import { writeAuditLog } from "../db/audit";
 
@@ -30,13 +31,25 @@ function audit(caller: any, entity: string, action: string, payload: any) {
 	}
 }
 
+const idPayloadSchema = z.object({ id: z.string().min(1) }).strict();
+const modulMutationSchema = z.discriminatedUnion("action", [
+	 z.object({ action: z.literal("upsert"), payload: ModulSchema }),
+	 z.object({ action: z.literal("remove"), payload: idPayloadSchema }),
+	 z.object({ action: z.literal("bulkSet"), payload: z.array(ModulSchema) }),
+]);
+const topikMutationSchema = z.discriminatedUnion("action", [
+	 z.object({ action: z.literal("upsert"), payload: TopikSchema }),
+	 z.object({ action: z.literal("remove"), payload: idPayloadSchema }),
+	 z.object({ action: z.literal("bulkSet"), payload: z.array(TopikSchema) }),
+]);
+const soalMutationSchema = z.discriminatedUnion("action", [
+	 z.object({ action: z.literal("upsert"), payload: SoalSchema }),
+	 z.object({ action: z.literal("remove"), payload: idPayloadSchema }),
+	 z.object({ action: z.literal("bulkSet"), payload: z.array(SoalSchema) }),
+]);
+
 export const mutateModulServer = createServerFn({ method: "POST" })
-	.validator(
-		z.object({
-			action: z.enum(["upsert", "remove", "bulkSet"]),
-			payload: z.any(),
-		}),
-	)
+	.validator(modulMutationSchema)
 	.handler(async ({ data }) => {
 		try {
 			await seedIfNeeded();
@@ -90,12 +103,7 @@ export const mutateModulServer = createServerFn({ method: "POST" })
 	});
 
 export const mutateTopikServer = createServerFn({ method: "POST" })
-	.validator(
-		z.object({
-			action: z.enum(["upsert", "remove", "bulkSet"]),
-			payload: z.any(),
-		}),
-	)
+	.validator(topikMutationSchema)
 	.handler(async ({ data }) => {
 		try {
 			await seedIfNeeded();
@@ -138,12 +146,7 @@ export const mutateTopikServer = createServerFn({ method: "POST" })
 	});
 
 export const mutateSoalServer = createServerFn({ method: "POST" })
-	.validator(
-		z.object({
-			action: z.enum(["upsert", "remove", "bulkSet"]),
-			payload: z.any(),
-		}),
-	)
+	.validator(soalMutationSchema)
 	.handler(async ({ data }) => {
 		try {
 			await seedIfNeeded();

--- a/src/lib/server/sesi/functions.ts
+++ b/src/lib/server/sesi/functions.ts
@@ -10,6 +10,7 @@ import {
 	operatorCanTouchUjian,
 	pesertaCanTouchUjian,
 } from "../db/auth";
+import { SesiUjianSchema } from "@/lib/cbt/types";
 import type { SesiUjian, NavKey } from "@/lib/cbt/types";
 import { writeAuditLog } from "../db/audit";
 import { stringifyJson, toBigInt, toNumber, parseJson } from "../db/json";
@@ -29,6 +30,25 @@ const OPERATOR_SESSION_KEYS: NavKey[] = [
 	"leaderboard",
 ];
 const SUBMIT_GRACE_MS = 30_000;
+
+const idPayloadSchema = z.object({ id: z.string().min(1) }).strict();
+const sesiMutationItemSchema = SesiUjianSchema.superRefine((item, ctx) => {
+	const soalIds = new Set(item.soalIds);
+	if (soalIds.size !== item.soalIds.length) {
+		ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Daftar soal sesi tidak boleh duplikat." });
+	}
+	if (item.mulaiAt !== undefined && item.selesaiAt !== undefined && item.selesaiAt < item.mulaiAt) {
+		ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Waktu selesai sesi tidak valid." });
+	}
+	if (item.jawaban.some((answer) => !soalIds.has(answer.soalId))) {
+		ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Jawaban mengacu pada soal yang tidak ada di sesi." });
+	}
+});
+const sesiMutationSchema = z.discriminatedUnion("action", [
+	 z.object({ action: z.literal("upsert"), payload: sesiMutationItemSchema }),
+	 z.object({ action: z.literal("remove"), payload: idPayloadSchema }),
+	 z.object({ action: z.literal("bulkSet"), payload: z.array(sesiMutationItemSchema) }),
+]);
 
 // Authoritative server-side grading at submit time. The participant's client
 // also computes a provisional grade for instant display, but the persisted
@@ -195,12 +215,7 @@ export const saveParticipantSesiServer = createServerFn({ method: "POST" })
 	});
 
 export const mutateSesiServer = createServerFn({ method: "POST" })
-	.validator(
-		z.object({
-			action: z.enum(["upsert", "remove", "bulkSet"]),
-			payload: z.any(),
-		}),
-	)
+	.validator(sesiMutationSchema)
 	.handler(async ({ data }) => {
 		try {
 			await seedIfNeeded();

--- a/src/lib/server/ujian/functions.ts
+++ b/src/lib/server/ujian/functions.ts
@@ -3,7 +3,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { prisma } from "../db/prisma";
-import { 
+import {
 	requireCaller, 
 	requireAdminResult,
 	seedIfNeeded,
@@ -12,6 +12,7 @@ import {
 	operatorCanTouchUjianInput,
 	pesertaCanTouchUjian,
 } from "../db/auth";
+import { TokenUjianSchema, UjianSchema } from "@/lib/cbt/types";
 import type { Ujian, TokenUjian } from "@/lib/cbt/types";
 import { writeAuditLog } from "../db/audit";
 import { Prisma } from "@prisma/client";
@@ -85,13 +86,31 @@ function validateUjianForSave(item: Ujian) {
 	}
 }
 
+const idPayloadSchema = z.object({ id: z.string().min(1) }).strict();
+const ujianMutationItemSchema = UjianSchema.superRefine((item, ctx) => {
+	if (!item.nama.trim()) ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Nama paket ujian wajib diisi." });
+	if (item.durasiMenit < 1) ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Durasi paket ujian harus minimal 1 menit." });
+	if (item.beginAt !== undefined && item.endAt !== undefined && item.endAt <= item.beginAt) {
+		ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Waktu selesai harus setelah waktu mulai." });
+	}
+	if (new Set(item.topicSets.map((set) => set.topikId)).size !== item.topicSets.length) {
+		ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Topik sumber soal tidak boleh duplikat." });
+	}
+});
+const ujianMutationSchema = z.discriminatedUnion("action", [
+	 z.object({ action: z.literal("upsert"), payload: ujianMutationItemSchema }),
+	 z.object({ action: z.literal("remove"), payload: idPayloadSchema }),
+	 z.object({ action: z.literal("bulkSet"), payload: z.array(ujianMutationItemSchema) }),
+	 z.object({ action: z.literal("publish"), payload: idPayloadSchema }),
+]);
+const tokenMutationSchema = z.discriminatedUnion("action", [
+	 z.object({ action: z.literal("upsert"), payload: TokenUjianSchema }),
+	 z.object({ action: z.literal("remove"), payload: idPayloadSchema }),
+	 z.object({ action: z.literal("bulkSet"), payload: z.array(TokenUjianSchema) }),
+]);
+
 export const mutateUjianServer = createServerFn({ method: "POST" })
-	.validator(
-		z.object({
-			action: z.enum(["upsert", "remove", "bulkSet", "publish"]),
-			payload: z.any(),
-		}),
-	)
+	.validator(ujianMutationSchema)
 	.handler(async ({ data }) => {
 		try {
 			await seedIfNeeded();
@@ -211,12 +230,7 @@ export const mutateUjianServer = createServerFn({ method: "POST" })
 	});
 
 export const mutateTokenServer = createServerFn({ method: "POST" })
-	.validator(
-		z.object({
-			action: z.enum(["upsert", "remove", "bulkSet"]),
-			payload: z.any(),
-		}),
-	)
+	.validator(tokenMutationSchema)
 	.handler(async ({ data }) => {
 		try {
 			await seedIfNeeded();

--- a/src/lib/server/users/functions.ts
+++ b/src/lib/server/users/functions.ts
@@ -6,9 +6,18 @@ import { requireCaller, requireAdminResult, seedIfNeeded } from "../db/auth";
 import { hashPassword } from "@/lib/cbt/hash";
 import { stringifyJson, parseJson } from "../db/json";
 import { publicUser, upsertUserSchema } from "../repos/mappers";
+import { UserSchema } from "@/lib/cbt/types";
 import type { User, PublicUser } from "@/lib/cbt/types";
 
 import { writeAuditLog } from "../db/audit";
+
+const idPayloadSchema = z.object({ id: z.string().min(1) }).strict();
+const userMutationSchema = z.discriminatedUnion("action", [
+	 z.object({ action: z.literal("upsert"), payload: UserSchema }),
+	 z.object({ action: z.literal("remove"), payload: idPayloadSchema }),
+	 z.object({ action: z.literal("bulkSet"), payload: z.array(UserSchema) }),
+	 z.object({ action: z.literal("bulkRemove"), payload: z.object({ ids: z.array(z.string().min(1)).min(1) }).strict() }),
+]);
 
 export const revokeUserSessionsServer = createServerFn({ method: "POST" })
 	.validator(z.object({ userId: z.string().min(1) }))
@@ -131,12 +140,7 @@ export const patchUserTopikAccessServer = createServerFn({ method: "POST" })
 	});
 
 export const mutateUserServer = createServerFn({ method: "POST" })
-	.validator(
-		z.object({
-			action: z.enum(["upsert", "remove", "bulkSet", "bulkRemove"]),
-			payload: z.any(),
-		}),
-	)
+	.validator(userMutationSchema)
 	.handler(async ({ data }) => {
 		try {
 			await seedIfNeeded();

--- a/tests/unit/exam-lifecycle.test.mjs
+++ b/tests/unit/exam-lifecycle.test.mjs
@@ -33,7 +33,7 @@ test("only published exams with explicit groups enter the participant snapshot",
 
 test("publish performs readiness checks before changing status", () => {
   const server = read("src/lib/server/ujian/functions.ts");
-  assert.match(server, /action: z\.enum\(\["upsert", "remove", "bulkSet", "publish"\]\)/);
+  assert.match(server, /const ujianMutationSchema = z\.discriminatedUnion\("action"/);
   assert.match(server, /if \(item\.topicSets\.length === 0\)/);
   assert.match(server, /if \(item\.groupIds\.length === 0 && parseJson/);
   assert.match(server, /if \(!item\.penawaranId\)/);

--- a/tests/unit/pr-guardrails.test.mjs
+++ b/tests/unit/pr-guardrails.test.mjs
@@ -78,7 +78,34 @@ test("production session cookies default secure but allow explicit private-HTTP 
   const compose = readFileSync("compose.yaml", "utf8");
 
   assert.match(session, /SESSION_COOKIE_SECURE !== "false"/);
-  assert.match(compose, /SESSION_COOKIE_SECURE: "false"/);
+  assert.match(compose, /SESSION_COOKIE_SECURE: "\$\{SESSION_COOKIE_SECURE:-true\}"/);
+});
+
+test("issue 150 hardens mutation and file boundaries", () => {
+  const mutationFiles = [
+    "src/lib/server/modul/functions.ts",
+    "src/lib/server/ujian/functions.ts",
+    "src/lib/server/sesi/functions.ts",
+    "src/lib/server/users/functions.ts",
+    "src/lib/server/backup/functions.ts",
+  ];
+  for (const path of mutationFiles) {
+    assert.doesNotMatch(readFileSync(path, "utf8"), /z\.any\(\)/, `${path} must validate payloads`);
+  }
+
+  const files = readFileSync("src/lib/server/files/functions.ts", "utf8");
+  const compose = readFileSync("compose.yaml", "utf8");
+  const dockerfile = readFileSync("Dockerfile", "utf8");
+
+  assert.match(files, /MAX_FILE_BYTES/);
+  assert.match(files, /MAX_STORAGE_BYTES/);
+  assert.match(files, /BASE64_PATTERN/);
+  assert.match(files, /operatorCanAccessFile/);
+  assert.match(files, /operatorCanTouchTopikId/);
+  assert.match(files, /operatorCanTouchUjian/);
+  assert.match(compose, /ADMIN_PASSWORD: "\$\{ADMIN_PASSWORD:\?set ADMIN_PASSWORD for production\}"/);
+  assert.match(compose, /SEED_DEMO: "\$\{SEED_DEMO:-false\}"/);
+  assert.doesNotMatch(dockerfile, /NODE_ENV=development npm run prisma:seed/);
 });
 
 test("migration normalizes only dangling optional relation IDs", () => {


### PR DESCRIPTION
## Ringkasan

- Masalah / kebutuhan: Issue #150 menemukan bypass scope pada pembacaan file langsung, payload mutation server yang terlalu longgar, upload/restore tanpa batas ukuran dan tipe, serta default deployment production yang tidak aman.
- Perubahan: Menambahkan validasi Zod berbasis domain dan discriminated union pada mutation modul/topik/soal/ujian/token/sesi/user/backup; menegakkan scope operator pada `getStoredFileUrl`; membatasi base64, MIME/ekstensi, ukuran file 10 MiB, dan quota storage 500 MiB; mengamankan default Compose dan seed production.
- Dampak pengguna/admin: Payload invalid ditolak sebelum authorization/persistence, operator hanya membaca file dalam scope-nya, file besar/bertipe arbitrary ditolak, dan deployment production tidak menyalakan demo seed secara default.

## Issue, PR terkait, dan riwayat

- Issue/PR terkait: Closes #150. PR #160 membahas issue #153 (audit/restore/health), bukan perubahan ini.
- Apakah ini replacement dari PR closed/stale? Jika ya, tulis nomor PR dan kontribusi yang diekstrak: Tidak.
- Mengapa perubahan ini tidak duplikat dari pekerjaan yang ada? Branch dibuat dari `upstream/main` terbaru dan hanya memuat boundary/security fixes issue #150. Audit dependency production sudah 0 vulnerability di base terbaru, sehingga tidak ada perubahan package/lockfile duplikat.

## Cadence dan review

- PR aktif lain oleh saya: Ya, PR #160 untuk issue #153.
- Jika ada PR aktif lain, alasan pekerjaan paralel dan maintainer yang memintanya: Issue #150 adalah temuan security/urgent yang independen; perubahan dipisahkan ke branch dan PR fokus tersendiri, bukan digabung ke PR #160.
- [x] Saya sudah mengecek PR aktif saya dan tidak membuka PR paralel tanpa permintaan maintainer atau kebutuhan security/urgent yang jelas.
- [x] CodeRabbit dijalankan pada head final; tindak lanjut review akan tetap di PR ini. (Bot merespons PR; review manual terkena rate limit karena PR masih draft.)

## Scope dan non-goal

- Dalam scope: Server-side payload validation, file authorization scope, upload/restore validation and quota, production Compose/seed defaults, regression guardrails.
- Tidak dalam scope: Perubahan Prisma schema/migration, redesign UI, penggantian dependency yang sudah bersih di `upstream/main`, atau pekerjaan issue #153–#156.
- File penting yang diubah: `src/lib/server/files/functions.ts`, `src/lib/server/modul/functions.ts`, `src/lib/server/ujian/functions.ts`, `src/lib/server/sesi/functions.ts`, `src/lib/server/users/functions.ts`, `src/lib/server/backup/functions.ts`, `compose.yaml`, `Dockerfile`, dan test guardrails.

## Keamanan, otorisasi, dan data

- [ ] Tidak menyentuh data privat, otorisasi, token, file, sesi, score, atau snapshot.
- [x] Server-side caller/role/ownership/scope telah diperiksa untuk setiap boundary yang disentuh.
- [x] Tidak ada UI-only authorization atau client-supplied ID yang dipercaya sebagai bukti akses.
- [x] Tidak ada jawaban benar, pembahasan, password hash, atau data peserta di luar scope yang terekspos.
- [x] Mutation sempit tidak memakai generic/full-record upsert dari partial list/monitor projection.
- [ ] Tidak relevan — jelaskan: Perubahan memang menyentuh boundary authorization, file, sesi, token, dan backup.

## Prisma dan migrasi

- [x] Tidak mengubah `prisma/schema.prisma`.
- [ ] Mengubah schema dan menambahkan migration baru di `prisma/migrations/`.
- [ ] Migration additive/data-preserving; rename/drop/relation rewrite memiliki backfill dan preflight data.
- [ ] `npx prisma validate` dan `npx prisma migrate deploy` telah dijalankan.
- [ ] Tidak relevan — jelaskan: Tidak ada perubahan schema/migration; gate tetap perlu dijalankan setelah dependency dapat di-install.

## UI dan aksesibilitas

- [x] Tidak mengubah UI.
- [ ] Alur UI diuji manual, termasuk loading/error state.
- [ ] Kontrol interaktif memakai semantic/native control atau komponen aksesibel.
- [ ] Keyboard, label/aria, dark mode, dan timezone/hydration telah diperiksa bila relevan.
- [x] Screenshot/rekaman terlampir atau tidak diperlukan karena: perubahan hanya server-side, deployment config, changelog, dan tests.

## Validasi yang benar-benar dijalankan

```text
[x] npm ci — GitHub CI passed; local runner terblokir policy `EALLOWREMOTE` untuk xlsx@https://cdn.sheetjs.com/...
[x] npm run lint -- --max-warnings=7 — GitHub CI passed.
[x] npm run typecheck — GitHub CI passed after the caller typing fix in commit `7b3523b`.
[x] npm run test:unit — GitHub CI passed (147 tests).
[x] npm run build — GitHub CI passed.
[ ] npx prisma validate — tidak dijalankan lokal; CI menjalankan verifikasi Prisma terhadap schema/migration.
[ ] npx prisma migrate deploy — tidak dijalankan lokal; CI menjalankan verifikasi Prisma terhadap schema/migration.
[x] node scripts/verify-prisma-schema.mjs — GitHub CI passed; schema/migration tidak berubah.
[x] npm audit --omit=dev --json — 0 vulnerabilities (base `upstream/main` juga 0).
[x] git diff --check
[x] Codebase Memory: traced shared callers and verified changed paths; no recorded coverage issue (best-effort).
```

## Hygiene check

- [x] Diff tidak memuat `scratch/**`, `ts_errors.txt`, `diff_users.txt`, raw/temp file, upload, database lokal, log, coverage, artifact, atau generated output.
- [x] Tidak mengubah package name, lockfile metadata, atau dependency tanpa alasan feature yang jelas.
- [x] Tidak mengembalikan branding `cbt-kampus` / `cbt-universitas`.
- [x] Tidak mengedit `src/routeTree.gen.ts` secara manual.
- [x] `git diff --check` bersih.
- [x] Branch dibuat dari `upstream/main` terbaru dan tidak membawa commit aggregate/stale yang tidak terkait.

## Risiko dan rollback

- Risiko yang tersisa: Backup lama dengan metadata MIME/ekstensi atau ukuran yang tidak konsisten akan ditolak; quota 500 MiB berlaku untuk seluruh local file storage. Gate build/typecheck penuh masih menunggu dependency install yang diizinkan.
- Rencana rollback/recovery bila perubahan gagal: Revert commit `2a6f686`; data existing tidak dimigrasikan atau dihapus oleh perubahan ini.
- Changelog `Unreleased` diperbarui / tidak diperlukan karena: `CHANGELOG.md` diperbarui untuk security fix issue #150.

## Checklist pengirim

- [x] Saya membaca `CONTRIBUTING.md`, `AGENTS.md`, dan `CLAUDE.md`.
- [x] Saya membaca seluruh template ini dan mengisi jawaban spesifik, bukan placeholder.
- [x] Saya siap menangani CI dan seluruh review thread pada head SHA terbaru.
- [x] Saya tidak meminta bypass CI, branch protection, atau merge sebelum review selesai.
